### PR TITLE
Remove images on docker-compose down

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ node {
         }
         always {
             tryStep "lint stop", {
-                sh "docker-compose -p ${PROJECT} down -v || true"
+                sh "docker-compose -p ${PROJECT} down --rmi local -v || true"
             }
         }
     }
@@ -41,7 +41,7 @@ node {
         }
         always {
             tryStep "test stop", {
-                sh "docker-compose -p ${PROJECT} down -v || true"
+                sh "docker-compose -p ${PROJECT} down --rmi local -v || true"
             }
         }
     }


### PR DESCRIPTION
Also remove any images build in the previous docker-compose up step. 

Intended to keep the number of images on the CI build system manageble.