### PR TITLE
Tidy up temporary Docker images after building/deploying

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // tag image, push to repo, remove local tagged image
 def tag_image_as(tag) {
   script {
-    docker.image("${DOCKER_IMAGE_URL}:${env.COMMIT_HASH}").image.push(tag)
+    docker.image("${DOCKER_IMAGE_URL}:${env.COMMIT_HASH}").push(tag)
     sh "docker rmi ${DOCKER_IMAGE_URL}:${tag} || true"
   }
 }


### PR DESCRIPTION
* The script now cleans up after itself by deleting (temporary) images after use.
* The script is also in some ways slightly simpler and easier to read.
* The URL of the Docker repository in no longer explicitly referenced.