### PR TITLE
refactor: drill property actionButtonsComponent into Search

### DIFF
--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -1,10 +1,14 @@
 import React, { FC } from "react"
 import SearchForm from "./SearchForm"
-import SearchResults from "./SearchResults"
+import SearchResults, {ActionButtonsComponentType} from "./SearchResults"
 import SmallSpinner from "../global/SmallSpinner"
 import useGlobalState from "../../hooks/useGlobalState"
 
-const Search: FC = () => {
+type Props = {
+  actionButtonsComponent?:ActionButtonsComponentType
+}
+
+const Search: FC<Props> = ({ actionButtonsComponent }) => {
 
   const {
     search: {
@@ -21,7 +25,10 @@ const Search: FC = () => {
       { showSpinner &&
         <SmallSpinner />
       }
-      <SearchResults results={ results } />
+      <SearchResults
+        results={ results }
+        actionButtonsComponent={actionButtonsComponent}
+      />
     </div>
   )
 }

--- a/src/components/search/SearchResult.tsx
+++ b/src/components/search/SearchResult.tsx
@@ -2,9 +2,11 @@ import React, { FC } from "react"
 import styled from "styled-components"
 import SearchResultSingle from "./SearchResultSingle"
 import SearchResultPlural from "./SearchResultPlural"
+import {ActionButtonsComponentType} from "./SearchResults"
 
 type Props = {
   cases: SearchResultCases
+  actionButtonsComponent?:ActionButtonsComponentType
 }
 
 const Div = styled.div`
@@ -12,7 +14,7 @@ const Div = styled.div`
   border-bottom: 1px solid #B4B4B4
 `
 
-const SearchResult: FC<Props> = ({ cases }) => {
+const SearchResult: FC<Props> = ({ cases, actionButtonsComponent }) => {
 
   const showPlural = cases.length > 1
   const caseItem = cases[0]
@@ -20,8 +22,8 @@ const SearchResult: FC<Props> = ({ cases }) => {
   return (
     <Div>
       { showPlural ?
-        <SearchResultPlural cases={ cases } /> :
-        <SearchResultSingle caseItem={ caseItem! } />
+        <SearchResultPlural cases={ cases } actionButtonsComponent={actionButtonsComponent} /> :
+        <SearchResultSingle caseItem={ caseItem! } actionButtonsComponent={actionButtonsComponent} />
       }
     </Div>
   )

--- a/src/components/search/SearchResultPlural.tsx
+++ b/src/components/search/SearchResultPlural.tsx
@@ -5,13 +5,15 @@ import SearchResultWrap from "./SearchResultWrap"
 import SearchResultAddress from "./SearchResultAddress"
 import SearchResultDistance from "./SearchResultDistance"
 import SearchResultCase from "./SearchResultCase"
-import SearchResultButtonWrap from "./SearchResultButtonWrap"
 
 import { to } from "../../config/page"
 import displayAddress from "../../lib/displayAddress"
 
+import {ActionButtonsComponentType} from "./SearchResults"
+
 type Props = {
   cases: SearchResultCases
+  actionButtonsComponent?:ActionButtonsComponentType
 }
 
 const Wrap = styled.div`
@@ -27,7 +29,7 @@ const Div = styled.div`
   justify-content: flex-end
 `
 
-const SearchResultPlural: FC<Props> = ({ cases }) => {
+const SearchResultPlural: FC<Props> = ({ actionButtonsComponent, cases }) => {
 
   const {
     street_name: streetName,
@@ -43,6 +45,8 @@ const SearchResultPlural: FC<Props> = ({ cases }) => {
 
   const address = displayAddress(streetName, streetNumber, suffix_letter || undefined, suffix || undefined)
   const showDistance = distance !== undefined
+
+  const ActionButtonsComponent = actionButtonsComponent
 
   return (
     <div>
@@ -65,9 +69,11 @@ const SearchResultPlural: FC<Props> = ({ cases }) => {
             <Link key={ key } to={ linkTo }>
               <Wrap>
                 <SearchResultCase reason={ reason } stadium={ stadium } teams={ teams } fraudProbability={ fraudProbability } />
-                <Div>
-                  <SearchResultButtonWrap caseId={ caseId } />
-                </Div>
+                { ActionButtonsComponent && (
+                  <Div>
+                    <ActionButtonsComponent caseId={caseId} />
+                  </Div>
+                ) }
               </Wrap>
             </Link>
           )

--- a/src/components/search/SearchResultSingle.tsx
+++ b/src/components/search/SearchResultSingle.tsx
@@ -5,15 +5,16 @@ import SearchResultMenu from "./SearchResultMenu"
 import SearchResultAddress from "./SearchResultAddress"
 import SearchResultDistance from "./SearchResultDistance"
 import SearchResultCase from "./SearchResultCase"
-import SearchResultButtonWrap from "./SearchResultButtonWrap"
 import { to } from "../../config/page"
 import displayAddress from "../../lib/displayAddress"
+import {ActionButtonsComponentType} from "./SearchResults"
 
 type Props = {
   caseItem: SearchResultCase
+  actionButtonsComponent?:ActionButtonsComponentType
 }
 
-const SearchResultSingle: FC<Props> = ({ caseItem }) => {
+const SearchResultSingle: FC<Props> = ({ caseItem, actionButtonsComponent }) => {
 
   const {
     case_id: caseId,
@@ -35,6 +36,8 @@ const SearchResultSingle: FC<Props> = ({ caseItem }) => {
   const address = displayAddress(streetName, streetNumber, suffix_letter || undefined, suffix || undefined)
   const showDistance = distance !== undefined
 
+  const ActionButtonsComponent = actionButtonsComponent
+
   return (
     <Link to={ linkTo }>
       <SearchResultWrap>
@@ -46,7 +49,10 @@ const SearchResultSingle: FC<Props> = ({ caseItem }) => {
           { showDistance &&
             <SearchResultDistance distance={ distance! } />
           }
-          <SearchResultButtonWrap caseId={ caseId } />
+          {
+            ActionButtonsComponent &&
+            <ActionButtonsComponent caseId={caseId} />
+          }
         </SearchResultMenu>
       </SearchResultWrap>
     </Link>

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -3,15 +3,19 @@ import styled from "styled-components"
 import SearchResult from "./SearchResult"
 import EmptySearchResult from "./EmptySearchResult"
 
+export type ActionButtonsComponentProps = { caseId: string }
+export type ActionButtonsComponentType = React.ComponentType<ActionButtonsComponentProps>
+
 type Props = {
   results?: SearchResults
+  actionButtonsComponent?:ActionButtonsComponentType
 }
 
 const P = styled.p`
   margin-top: 12px
 `
 
-const SearchResults: FC<Props> = ({ results }) => {
+const SearchResults: FC<Props> = ({ results, actionButtonsComponent }) => {
 
   const showResults = results && results.length > 0
   const showEmpty = results && results.length === 0
@@ -28,7 +32,7 @@ const SearchResults: FC<Props> = ({ results }) => {
         return (
           <div key={ `${ JSON.stringify(result) }_${ index }` }>
             { showSearchResult &&
-              <SearchResult cases={ data!.cases } />
+              <SearchResult cases={ data!.cases } actionButtonsComponent={actionButtonsComponent} />
             }
             { showEmptySearchResult &&
               <EmptySearchResult text={ error } />

--- a/src/components/search/Suggestions.tsx
+++ b/src/components/search/Suggestions.tsx
@@ -5,6 +5,7 @@ import useGlobalState from "../../hooks/useGlobalState"
 import SearchResults from "../search/SearchResults"
 import H1 from "../styled/H1"
 import Hr from "../styled/Hr"
+import ItinerarySearchResultButtons from "./itinerary/ItinerarySearchResultButtons"
 
 type Props = {
   id: Id
@@ -47,7 +48,7 @@ const Suggestions: FC<Props> = ({ id }) => {
           <H1>Voeg een adres toe</H1>
           <p>Addressen rondom de adressen in je lijst:</p>
           <Hr />
-          <SearchResults results={ results } />
+          <SearchResults results={ results } actionButtonsComponent={ItinerarySearchResultButtons} />
         </>
       }
     </div>

--- a/src/components/search/itinerary/ItinerarySearchResultButtons.tsx
+++ b/src/components/search/itinerary/ItinerarySearchResultButtons.tsx
@@ -1,10 +1,10 @@
 import React, { FC, useState, FormEvent } from "react"
-import useGlobalState from "../../hooks/useGlobalState"
-import IconButton from "../global/IconButton"
+import useGlobalState from "../../../hooks/useGlobalState"
+import IconButton from "../../global/IconButton"
 import { Button } from "@datapunt/asc-ui"
 import styled from "styled-components"
-import getItineraryByCaseId from "../../lib/getItineraryByCaseId"
-import TeamMembersDisplay from "../itineraries/TeamMembersDisplay"
+import getItineraryByCaseId from "../../../lib/getItineraryByCaseId"
+import TeamMembersDisplay from "../../itineraries/TeamMembersDisplay"
 
 type Props = {
   caseId: CaseId
@@ -31,7 +31,7 @@ const P = styled.p`
   font-weight: normal
 `
 
-const SearchResultButtonWrap: FC<Props> = ({ caseId }) => {
+const ItinerarySearchResultButtons: FC<Props> = ({ caseId }) => {
 
   const {
     hasItinerary: userHasItinerary,
@@ -114,4 +114,4 @@ const SearchResultButtonWrap: FC<Props> = ({ caseId }) => {
     </div>
   )
 }
-export default SearchResultButtonWrap
+export default ItinerarySearchResultButtons

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react"
 import { RouteComponentProps } from "@reach/router"
 import Search from "../components/search/Search"
 import Navigation from "../components/global/Navigation"
+import ItinerarySearchResultButtons from "../components/search/itinerary/ItinerarySearchResultButtons"
 
 type Props = RouteComponentProps
 
@@ -10,7 +11,7 @@ const SearchPage: FC<Props> = () => {
   return (
     <>
       <Navigation />
-      <Search />
+      <Search actionButtonsComponent={ItinerarySearchResultButtons} />
     </>
   )
 }


### PR DESCRIPTION
- Renamed `SearchResultButtonWrap` to `ItinerarySearchResultButtons`
- Drill property `actionButtonsComponent` into `Search` and pass along `ItinerarySearchResultButtons`.

When we can pass in a different `actionButtonsComponent`, we can reuse the `Search` component for different purposes (e.g. for 'add start address')