### PR TITLE
Use useCallback and remove useMemo's

### DIFF
--- a/src/components/search/Suggestions.tsx
+++ b/src/components/search/Suggestions.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react"
+import React, { FC, useEffect, useCallback } from "react"
 import Spinner from "../global/Spinner"
 import ErrorMessage from "../global/ErrorMessage"
 import useGlobalState from "../../hooks/useGlobalState"
@@ -25,9 +25,11 @@ const Suggestions: FC<Props> = ({ id }) => {
     }
   } = useGlobalState()
 
+  const getSuggestionsStable = useCallback(getSuggestions, [])
+
   useEffect(() => {
-    getSuggestions(id)
-  }, [id]) // eslint-disable-line react-hooks/exhaustive-deps
+    getSuggestionsStable(id)
+  }, [getSuggestionsStable, id])
 
   const showSpinner = !isInitialized || isFetching
   const hasError = errorMessage !== undefined

--- a/src/state/useAuth.ts
+++ b/src/state/useAuth.ts
@@ -1,4 +1,4 @@
-import {useReducer, useMemo} from "react"
+import { useReducer } from "react"
 import reducer, {
   initialState,
   createInitialize,
@@ -66,11 +66,8 @@ const useAuth = () : [AuthState, AuthActions] => {
     if (navigate) navigateToLogin()
   }
 
-  // We memoize the action creators to ensure it only re-triggers a hook when state changes
   const actionCreators = { initialize, authenticate, unAuthenticate }
-  const actionCreatorsMemoized = useMemo(() => actionCreators, [actionCreators])
-
-  return [auth, actionCreatorsMemoized]
+  return [auth, actionCreators]
 }
 
 export default useAuth

--- a/src/state/useItineraries.ts
+++ b/src/state/useItineraries.ts
@@ -1,4 +1,4 @@
-import {useReducer, useMemo} from "react"
+import { useReducer } from "react"
 import reducer, {
   initialState,
   createStartFetching,
@@ -204,16 +204,14 @@ const useItineraries = () : [ItinerariesState, ItinerariesActions, ItinerariesSe
 
   // We memoize the action creators to ensure it only re-triggers a hook when state changes
   const actionCreators = { initialize, create, updateTeam, del: del2, add, move, remove, setNote, clear, setChecked }
-  const actionCreatorsMemoized = useMemo(() => actionCreators, [actionCreators])
 
   // We memoize the selectors to ensure it only re-triggers a hook when state changes
   const selectors = { getItinerary, hasItinerary, getItineraryNote }
-  const selectorsMemoized = useMemo(() => selectors, [selectors])
 
   return [
     itinerariesState,
-    actionCreatorsMemoized,
-    selectorsMemoized
+    actionCreators,
+    selectors
   ]
 }
 export default useItineraries

--- a/src/state/usePlanningSettings.ts
+++ b/src/state/usePlanningSettings.ts
@@ -1,4 +1,4 @@
-import {useReducer, useMemo} from "react"
+import { useReducer } from "react"
 import reducer, {
   initialState,
   createStartFetching,
@@ -57,11 +57,9 @@ const usePlanningSettings = () : [PlanningSettingsState, PlanningSettingsActions
     dispatch(createSetData({ ...data, settings }))
   }
 
-  // We memoize the action creators to ensure it only re-triggers a hook when state changes
   const actionCreators = { initialize, saveSettings, clear }
-  const actionCreatorsMemoized = useMemo(() => actionCreators, [actionCreators])
 
-  return [state, actionCreatorsMemoized]
+  return [state, actionCreators]
 }
 
 export default usePlanningSettings

--- a/src/state/useSearch.ts
+++ b/src/state/useSearch.ts
@@ -1,4 +1,4 @@
-import {useReducer, useMemo} from "react"
+import { useReducer } from "react"
 import reducer, {
   initialState,
   createStartFetching,
@@ -83,11 +83,9 @@ const useSearch = () : [SearchState, SearchActions] => {
     dispatch(createClear())
   }
 
-  // We memoize the selectors to ensure it only re-triggers a hook when state changes
   const actionCreators = { search, getSuggestions, setTeam, clear }
-  const actionCreatorsMemoized = useMemo(() => actionCreators, [actionCreators])
 
-  return [state, actionCreatorsMemoized]
+  return [state, actionCreators]
 }
 
 export default useSearch

--- a/src/state/useUsers.ts
+++ b/src/state/useUsers.ts
@@ -1,4 +1,4 @@
-import {useReducer, useMemo} from "react"
+import { useReducer } from "react"
 import reducer, {
   initialState,
   createStartFetching,
@@ -33,12 +33,9 @@ const useUsers = () : [UsersState, UsersActions] => {
     dispatch(createClear())
   }
 
-  // We wrap the action-creators in a 'ref' to ensure it never re-triggers a hook:
-  // The action-creators themselves should never change.
   const actionCreators = { initialize, clear }
-  const actionCreatorsMemoized = useMemo(() => actionCreators, [actionCreators])
 
-  return [state, actionCreatorsMemoized]
+  return [state, actionCreators]
 }
 
 export default useUsers


### PR DESCRIPTION
Removed the useMemo / useRef from the actionCreators.

Retriggering useEffect problem can be solved with useCallback like:
```
const getSuggestionsStable = useCallback(getSuggestions, [])

useEffect(() => {
  getSuggestionsStable(id)
}, [getSuggestionsStable, id])
```
