### PR TITLE
fix: hide outline on draggable

### DIFF
--- a/src/components/itineraries/DraggableItineraryItem.tsx
+++ b/src/components/itineraries/DraggableItineraryItem.tsx
@@ -77,6 +77,7 @@ const DraggableItineraryItem: FC<Props> = ({ itineraryItem, index }) => {
     borderBottom: "1px solid #B4B4B4",
     boxShadow: isDragging ? "0 2px 20px black" : "none",
     padding: isDragging ? "0 20px" : 0,
+    outline: 0,
     ...draggableStyle
   })
 


### PR DESCRIPTION
Hides blue outline draggable on mobile when checked

![Screen Shot 2020-04-09 at 10 53 42 AM](https://user-images.githubusercontent.com/248906/78877016-7d840d80-7a50-11ea-8095-f36bdbb95f14.png)
