### PR TITLE
feat: show fraud-probability placeholder when no percentage is known

### DIFF
--- a/src/components/global/FraudProbability.tsx
+++ b/src/components/global/FraudProbability.tsx
@@ -1,13 +1,15 @@
 import React, { FC } from "react"
-import Emoji from "./Emoji"
+import FraudProbabilityLabel from "./FraudProbabiltyLabel"
 
 type Props = {
   fraudProbability: number
   className?: string
 }
 
-const FraudProbability: FC<Props> = ({ fraudProbability, className }) => {
-  const fraudProbabilityPercentage = Math.round(fraudProbability * 100)
-  return <span className={ className }><Emoji text="🤖" /> { fraudProbabilityPercentage }%</span>
-}
+const FraudProbability: FC<Props> = ({ fraudProbability, className }) => (
+  <FraudProbabilityLabel className={className}>
+    {Math.round(fraudProbability * 100)}%
+  </FraudProbabilityLabel>
+)
+
 export default FraudProbability

--- a/src/components/global/FraudProbabiltyLabel.tsx
+++ b/src/components/global/FraudProbabiltyLabel.tsx
@@ -1,0 +1,11 @@
+import React, { FC } from "react"
+import Emoji from "./Emoji"
+
+type Props = {
+  className?: string
+}
+
+const FraudProbabilityLabel: FC<Props> = ({ children, className }) =>
+  <span className={ className }><Emoji text="🤖" /> { children }</span>
+
+export default FraudProbabilityLabel

--- a/src/components/itineraries/Itinerary.tsx
+++ b/src/components/itineraries/Itinerary.tsx
@@ -75,7 +75,7 @@ const Itinerary: FC<Props> = ({ itinerary }) => {
     <div>
       <Wrap>
         <h1>{ title }</h1>
-        <Button variant="blank" iconRight={ <ChevronDown /> } onClick={ onClickOptions }>opties</Button>
+        <Button variant="blank" iconRight={ <ChevronDown /> } onClick={ onClickOptions }>Opties</Button>
       </Wrap>
       { showDialog &&
         <ButtonMenuWrap>

--- a/src/components/itineraries/ItineraryItem.tsx
+++ b/src/components/itineraries/ItineraryItem.tsx
@@ -7,6 +7,7 @@ import StadiumBadge from "../global/StadiumBadge"
 import Notes from "./notes/Notes"
 import FraudProbability from "../global/FraudProbability"
 import displayAddress from "../../lib/displayAddress"
+import FraudProbabilityLabel from "../global/FraudProbabiltyLabel"
 
 
 type Props = {
@@ -46,6 +47,12 @@ const StyledFraudProbability = styled(FraudProbability)`
   color: ${ color("tint", "level4") };
 `
 
+const StyledFraudLabel = styled(FraudProbabilityLabel)`
+  margin-left: ${ SPACING }px;
+  font-weight: normal;
+  color: ${ color("tint", "level4") };
+`
+
 const ItineraryItem: FC<Props> = ({ caseItem, fraudPrediction, notes, showAddress = true }) => {
   const {
     case_id: id,
@@ -71,11 +78,17 @@ const ItineraryItem: FC<Props> = ({ caseItem, fraudPrediction, notes, showAddres
           { showAddress &&
             <>
               <H1>{ address }</H1>
-              <PostalCode>{ postalCode }</PostalCode>
+              <PostalCode>
+                { postalCode }
+                { showFraudProbability
+                  ? <StyledFraudProbability fraudProbability={ fraudProbability! } />
+                  : <StyledFraudLabel>% onbekend</StyledFraudLabel>
+                }
+              </PostalCode>
             </>
           }
           <div>
-            <P>{ caseReason }{ showFraudProbability && <StyledFraudProbability fraudProbability={ fraudProbability! } /> }</P>
+            <P>{ caseReason }</P>
             <StadiumBadge text={ stadium } />
             <Notes notes={ notes } />
           </div>

--- a/src/components/search/SearchResultAddress.tsx
+++ b/src/components/search/SearchResultAddress.tsx
@@ -1,9 +1,13 @@
 import React, { FC } from "react"
 import styled from "styled-components"
+import FraudProbability from "../global/FraudProbability"
+import {color} from "@datapunt/asc-ui"
+import FraudProbabilityLabel from "../global/FraudProbabiltyLabel"
 
 type Props = {
   address: string
   postalCode: PostalCode
+  fraudProbability?: number
 }
 
 const H1 = styled.h1`
@@ -15,10 +19,27 @@ const PostalCode = styled.p`
   margin: 6px 0;
 `
 
-const SearchResultAddress: FC<Props> = ({ address, postalCode }) => (
+const StyledFraudProbability = styled(FraudProbability)`
+  margin-left: 12px;
+  font-weight: bold;
+  color: ${ color("tint", "level4") };
+`
+const StyledFraudLabel = styled(FraudProbabilityLabel)`
+  margin-left: 12px;
+  font-weight: normal;  
+  color: ${ color("tint", "level4") };  
+`
+
+const SearchResultAddress: FC<Props> = ({ address, postalCode, fraudProbability }) => (
   <div>
     <H1>{ address }</H1>
-    <PostalCode>{ postalCode }</PostalCode>
+    <PostalCode>
+      { postalCode }
+      { fraudProbability !== undefined
+        ? <StyledFraudProbability fraudProbability={ fraudProbability! } />
+        : <StyledFraudLabel>% onbekend</StyledFraudLabel>
+      }
+    </PostalCode>
   </div>
 )
 export default SearchResultAddress

--- a/src/components/search/SearchResultCase.tsx
+++ b/src/components/search/SearchResultCase.tsx
@@ -1,9 +1,7 @@
 import React, { FC } from "react"
 import styled from "styled-components"
 import StadiumBadge from "../global/StadiumBadge"
-import FraudProbability from "../global/FraudProbability"
 import useGlobalState from "../../hooks/useGlobalState"
-import { color } from "@datapunt/asc-ui"
 
 type Props = {
   reason: string
@@ -17,12 +15,8 @@ const P = styled.p`
   color: black;
   margin: 6px 0;
 `
-const StyledFraudProbability = styled(FraudProbability)`
-  margin-left: 12px;
-  font-weight: bold;
-  color: ${ color("tint", "level4") };
-`
-const SearchResultCase: FC<Props> = ({ reason, stadium, teams, fraudProbability }) => {
+
+const SearchResultCase: FC<Props> = ({ reason, stadium, teams }) => {
   const {
     auth: {
       user: { email = "" } = {}
@@ -42,11 +36,9 @@ const SearchResultCase: FC<Props> = ({ reason, stadium, teams, fraudProbability 
     (isOwnTeam && hasSingleItinerary ? "In mijn lijst" : `In lijst: ${ teamString }`) :
     ""
 
-  const showFraudProbability = fraudProbability !== undefined
-
   return (
     <div>
-      <P>{ reason }{ showFraudProbability && <StyledFraudProbability fraudProbability={ fraudProbability! } /> }</P>
+      <P>{ reason }</P>
       <StadiumBadge text={ stadium } />
       { showTeam &&
         <P>{ team }</P>

--- a/src/components/search/SearchResultSingle.tsx
+++ b/src/components/search/SearchResultSingle.tsx
@@ -49,7 +49,7 @@ const SearchResultSingle: FC<Props> = ({ caseItem, actionButtonsComponent, caseT
     <SearchResultWrap>
       <StyledLink to={ caseTo ? caseTo(caseId) : defaultCaseTo(caseId) }>
         <div>
-          <SearchResultAddress address={ address } postalCode={ postalCode } />
+          <SearchResultAddress address={ address } postalCode={ postalCode } fraudProbability={ fraudProbability } />
           <SearchResultCase reason={ reason } stadium={ stadium } teams={ teams } fraudProbability={ fraudProbability } />
         </div>
       </StyledLink>


### PR DESCRIPTION
- Moves fraud_probabilty next to the postal-code.
- Shows a '% onbekend' - label when no fraud_probability is known.

https://trello.com/c/Yko6otYp/267-hitkans-ontbreekt-bij-adres-in-gegenereerde-looplijst


