### PR TITLE
chore: move devDependencies from dependencies to devDependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DIR /var/www
 
 WORKDIR $DIR
 COPY . $DIR
-RUN npm ci --unsafe-perm .
+RUN npm ci --unsafe-perm --only=production .
 RUN npm run build
 
 FROM nginx:stable-alpine

--- a/package.json
+++ b/package.json
@@ -6,16 +6,6 @@
     "@datapunt/asc-assets": "^0.19.1",
     "@datapunt/asc-ui": "^0.19.2-beta.1",
     "@reach/router": "^1.3.3",
-    "@types/dompurify": "^2.0.1",
-    "@types/jest": "^25.2.1",
-    "@types/jwt-decode": "^2.2.1",
-    "@types/node": "^13.11.1",
-    "@types/reach__router": "^1.3.4",
-    "@types/react": "^16.9.34",
-    "@types/react-beautiful-dnd": "^12.1.2",
-    "@types/react-dom": "^16.9.6",
-    "@types/smoothscroll-polyfill": "^0.3.1",
-    "@types/styled-components": "^5.1.0",
     "abortcontroller-polyfill": "^1.4.0",
     "dompurify": "^2.0.8",
     "final-form": "^4.19.1",
@@ -28,7 +18,24 @@
     "react-final-form": "^6.4.0",
     "react-scripts": "^3.4.1",
     "smoothscroll-polyfill": "^0.4.4",
-    "styled-components": "^5.1.0",
+    "styled-components": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/dompurify": "^2.0.1",
+    "@types/jest": "^25.2.1",
+    "@types/jwt-decode": "^2.2.1",
+    "@types/node": "^13.11.1",
+    "@types/reach__router": "^1.3.4",
+    "@types/react": "^16.9.34",
+    "@types/react-beautiful-dnd": "^12.1.2",
+    "@types/react-dom": "^16.9.6",
+    "@types/smoothscroll-polyfill": "^0.3.1",
+    "@types/styled-components": "^5.1.0",
+    "@types/enzyme": "^3.10.5",
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-react-16": "^1.15.2",
+    "husky": "^4.2.5",
+    "lint-staged": "^10.1.3",
     "typescript": "^3.8.3"
   },
   "scripts": {
@@ -56,13 +63,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "@types/enzyme": "^3.10.5",
-    "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.2",
-    "husky": "^4.2.5",
-    "lint-staged": "^10.1.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Moved all development dependencies from `dependencies` to `devDependencies`.