### PR TITLE
fix: daypart settings are not required

### DIFF
--- a/src/components/planning/DayPartSettings.tsx
+++ b/src/components/planning/DayPartSettings.tsx
@@ -37,14 +37,14 @@ const DayPartSettings:React.FC<Props> = ({day, index: dayIndex, stadia}) => {
       <StadiumSettings
         fieldName={secondaryStadia}
         stadia={stadia}
-        validate={combineValidators(isNotIntersectingWith(excludeStadia), isRequired)}
+        validate={isNotIntersectingWith(excludeStadia)}
       />
 
       <H4>3. Uitsluiten</H4>
       <StadiumSettings
         fieldName={excludeStadia}
         stadia={stadia}
-        validate={combineValidators(isNotIntersectingWith(secondaryStadia), isRequired)}
+        validate={isNotIntersectingWith(secondaryStadia)}
       />
     </Wrap>
   )


### PR DESCRIPTION
After a chat with Yvonne we'd noticed that the DayPartSettings are required now, but they shouldn't be.