### PR TITLE
Refactor: introduce map in planning-settings to be index independent.

### DIFF
--- a/src/components/form-components/validators/isNotIntersectingWith.ts
+++ b/src/components/form-components/validators/isNotIntersectingWith.ts
@@ -11,6 +11,10 @@ import { getIn } from 'final-form'
 export const isNotIntersectingWith = (field:string) => (value:any, allValues:object) => {
   const other = getIn(allValues, field)
 
+  if (value === undefined || other === undefined) {
+    return undefined
+  }
+
   if (!Array.isArray(value) || !Array.isArray(other)) {
     console.error('Fields should be arrays')
     return undefined

--- a/src/components/itineraries/Generate/Generate.tsx
+++ b/src/components/itineraries/Generate/Generate.tsx
@@ -2,7 +2,6 @@ import React, { FC, useState } from "react"
 import { Form } from "react-final-form"
 import { Button, Label } from "@datapunt/asc-ui"
 import {Link} from "@reach/router"
-import { listsDay } from "../../../config/planning"
 import useGlobalState from "../../../hooks/useGlobalState"
 import styled from "styled-components"
 import isWeekDay from "../../../lib/utils/isWeekDay"
@@ -14,6 +13,7 @@ import TeamMemberFields from "../TeamMemberFields"
 import RadioFieldGroup from "../../form-components/RadioFieldGroup"
 import NumberField from "../../form-components/NumberField"
 import {isRequired} from "../../form-components/validators/isRequired"
+import {getCurrentDay} from "../../../lib/utils/day"
 
 const Div = styled.div`
   margin-bottom: 24px;
@@ -31,7 +31,7 @@ const ButtonWrap = styled.div`
   justify-content: flex-end;
 `
 
-type DayPart = "day" | "evening"
+
 type FormValues = {
   num: number
   dayPart: DayPart
@@ -39,13 +39,22 @@ type FormValues = {
 }
 
 const getListSettingsForDayPart = (settings: PlanningSettings, dayPart: DayPart, startAddressCaseId?: string) => {
-  const day = (new Date()).getDay()
-  // @TODO: Extract this to lib/util function
-  const dayIndex = day - 1 < 0 ? 6 : day - 1 // correct sunday => 6
-  const dayLists = listsDay(settings.lists, dayIndex)
-  // @TODO: Extract this to config/planning.ts
-  const lists = dayLists.length >= 2 && dayPart === "evening" ? dayLists[1] : dayLists[0]
-  return {...settings, lists, startAddressCaseId}
+  const currentDay = getCurrentDay()
+
+  // saturday and sundays don't do evenings:
+  if (currentDay === 'saturday' || currentDay === 'sunday') {
+    dayPart = 'day'
+  }
+
+  const list = settings
+    .lists
+    .find(list => list.day === currentDay && list.dayPart === dayPart)
+
+  return {
+    ...settings,
+    list,
+    startAddressCaseId
+  }
 }
 
 const Generate: FC = () => {

--- a/src/components/itineraries/Generate/Generate.tsx
+++ b/src/components/itineraries/Generate/Generate.tsx
@@ -46,13 +46,9 @@ const getListSettingsForDayPart = (settings: PlanningSettings, dayPart: DayPart,
     dayPart = 'day'
   }
 
-  const list = settings
-    .lists
-    .find(list => list.day === currentDay && list.dayPart === dayPart)
-
   return {
     ...settings,
-    list,
+    days: settings.days[currentDay][dayPart],
     startAddressCaseId
   }
 }

--- a/src/components/planning/DayPartSettings.tsx
+++ b/src/components/planning/DayPartSettings.tsx
@@ -1,62 +1,61 @@
 import React from "react"
 import styled from "styled-components"
+import { AccordionWrapper, Accordion } from "@datapunt/asc-ui"
 import {StadiumSettings} from "./StadiumSettings"
 import {isNotIntersectingWith} from "../form-components/validators/isNotIntersectingWith"
-//import {combineValidators} from "../form-components/validators/combineValidators"
-//import {isRequired} from "../form-components/validators/isRequired"
 import SelectField from "../form-components/SelectField"
-import {Field} from "react-final-form"
 
 type Props = {
   title: string,
-  index: number
   day: Day,
   dayPart: DayPart,
   stadia: Stadia
 }
 
-const Wrap = styled.div`
-  padding: 20px 0;
+const StyledAccordionWrapper = styled(AccordionWrapper)`
+  
+`
+
+const StyledAccordion = styled(Accordion)`
+  // UX wants the accordion headers bold.  
+  span {
+    font-weight: bold;
+  }
 `
 
 const H4 = styled.h4`
   margin: 18px 0 4px
 `
 
-const getFieldName = (dayIndex:number, name:string) =>
-  `lists[${dayIndex}].${name}`
+const getFieldName = (day:Day, dayPart:DayPart, name:string) =>
+  `days.${day}.${dayPart}.${name}`
 
-const DayPartSettings:React.FC<Props> = ({index: dayIndex, title, day, dayPart, stadia}) => {
-  const primaryStadium = getFieldName(dayIndex, 'primary_stadium')
-  const secondaryStadia = getFieldName(dayIndex, 'secondary_stadia')
-  const excludeStadia = getFieldName(dayIndex, 'exclude_stadia')
-  const dayName = getFieldName(dayIndex, 'day')
-  const dayPartName = getFieldName(dayIndex, 'dayPart')
+const DayPartSettings:React.FC<Props> = ({title, day, dayPart, stadia}) => {
+  const primaryStadium = getFieldName(day, dayPart, 'primary_stadium')
+  const secondaryStadia = getFieldName(day, dayPart, 'secondary_stadia')
+  const excludeStadia = getFieldName(day, dayPart, 'exclude_stadia')
+
   const options = stadia.reduce((acc, stadium) => ({ ...acc, [stadium]:stadium }), { '': 'Geen' })
 
   return (
-    <Wrap>
-      <Field name={dayName} component='input' type='hidden' initialValue={day} />
-      <Field name={dayPartName} component='input' type='hidden' initialValue={dayPart} />
-
-      <h1>{title}</h1>
+    <AccordionWrapper>
+      <StyledAccordion title={title} isOpen={dayPart !== 'evening'}>
       <H4>1. Zoveel mogelijk</H4>
       <SelectField name={primaryStadium} options={options} />
-
       <H4>2. Aanvullen met</H4>
       <StadiumSettings
         fieldName={secondaryStadia}
         stadia={stadia}
         validate={isNotIntersectingWith(excludeStadia)}
       />
-
       <H4>3. Uitsluiten</H4>
       <StadiumSettings
         fieldName={excludeStadia}
         stadia={stadia}
         validate={isNotIntersectingWith(secondaryStadia)}
       />
-    </Wrap>
+      </StyledAccordion>
+    </AccordionWrapper>
   )
 }
 

--- a/src/components/planning/DayPartSettings.tsx
+++ b/src/components/planning/DayPartSettings.tsx
@@ -5,10 +5,13 @@ import {isNotIntersectingWith} from "../form-components/validators/isNotIntersec
 //import {combineValidators} from "../form-components/validators/combineValidators"
 //import {isRequired} from "../form-components/validators/isRequired"
 import SelectField from "../form-components/SelectField"
+import {Field} from "react-final-form"
 
 type Props = {
+  title: string,
   index: number
-  day: string
+  day: Day,
+  dayPart: DayPart,
   stadia: Stadia
 }
 
@@ -20,16 +23,23 @@ const H4 = styled.h4`
   margin: 18px 0 4px
 `
 
-const DayPartSettings:React.FC<Props> = ({day, index: dayIndex, stadia}) => {
-  const primaryStadium = `lists[${dayIndex}].primary_stadium`
-  const secondaryStadia = `lists[${dayIndex}].secondary_stadia`
-  const excludeStadia = `lists[${dayIndex}].exclude_stadia`
+const getFieldName = (dayIndex:number, name:string) =>
+  `lists[${dayIndex}].${name}`
 
+const DayPartSettings:React.FC<Props> = ({index: dayIndex, title, day, dayPart, stadia}) => {
+  const primaryStadium = getFieldName(dayIndex, 'primary_stadium')
+  const secondaryStadia = getFieldName(dayIndex, 'secondary_stadia')
+  const excludeStadia = getFieldName(dayIndex, 'exclude_stadia')
+  const dayName = getFieldName(dayIndex, 'day')
+  const dayPartName = getFieldName(dayIndex, 'dayPart')
   const options = stadia.reduce((acc, stadium) => ({ ...acc, [stadium]:stadium }), { '': 'Geen' })
 
   return (
     <Wrap>
-      <h1>{day}</h1>
+      <Field name={dayName} component='input' type='hidden' initialValue={day} />
+      <Field name={dayPartName} component='input' type='hidden' initialValue={dayPart} />
+
+      <h1>{title}</h1>
       <H4>1. Zoveel mogelijk</H4>
       <SelectField name={primaryStadium} options={options} />
 

--- a/src/components/planning/Settings.tsx
+++ b/src/components/planning/Settings.tsx
@@ -24,10 +24,27 @@ const DateInputWrap = styled.div`
 const Div = styled.div`
   margin-bottom: 36px;
 `
-const ColumnWrap = styled(Div)`
+const ColumnWrap = styled(Div)`       
   column-count: 3;
   @media screen and ${ breakpoint("min-width", "laptopL") } {
-    column-count: 6;
+    column-count: 5;
+    
+  }
+`
+
+const DayPartSettingsWrap = styled(Div)`
+  display: inline-block;
+    
+  vertical-align: top;
+  width: 33%; // Three columns
+  padding-right: 20px;
+  
+  &:last-of-type {
+    padding-right: 0px;
+  }
+  
+  @media screen and ${ breakpoint("min-width", "laptopL") } {    
+    width: 20%;   // Five columns
   }
 `
 
@@ -53,18 +70,24 @@ export type DayPartConfig = {
 }
 
 const DAY_PARTS:DayPartConfig[] = [
-  {day: 'monday', dayPart: 'day', title: 'Maandag'},
-  {day: 'monday', dayPart: 'evening', title: 'Maandag avond'},
-  {day: 'tuesday', dayPart: 'day', title: 'Dinsdag'},
-  {day: 'tuesday', dayPart: 'evening', title: 'Dinsdag avond'},
-  {day: 'wednesday', dayPart: 'day', title: 'Woensdag'},
-  {day: 'wednesday', dayPart: 'evening', title: 'Woensdag avond'},
-  {day: 'thursday', dayPart: 'day', title: 'Donderdag'},
-  {day: 'thursday', dayPart: 'evening', title: 'Donderdag avond'},
-  {day: 'friday', dayPart: 'day', title: 'Vrijdag'},
-  {day: 'friday', dayPart: 'evening', title: 'Vrijdag avond'},
+  {day: 'monday', dayPart: 'day', title: 'Maandag dag' },
+  {day: 'tuesday', dayPart: 'day', title: 'Dinsdag dag'},
+  {day: 'wednesday', dayPart: 'day', title: 'Woensdag dag'},
+  {day: 'thursday', dayPart: 'day', title: 'Donderdag dag'},
+  {day: 'friday', dayPart: 'day', title: 'Vrijdag dag'},
+]
+
+const WEEKEND:DayPartConfig[] = [
   {day: 'saturday', dayPart: 'day', title: 'Zaterdag weekend'},
   {day: 'sunday', dayPart: 'day', title: 'Zondag weekend'},
+]
+
+const EVENINGS:DayPartConfig[] = [
+  {day: 'monday', dayPart: 'evening', title: 'Maandag avond'},
+  {day: 'tuesday', dayPart: 'evening', title: 'Dinsdag avond'},
+  {day: 'wednesday', dayPart: 'evening', title: 'Woensdag avond'},
+  {day: 'thursday', dayPart: 'evening', title: 'Donderdag avond'},
+  {day: 'friday', dayPart: 'evening', title: 'Vrijdag avond'}
 ]
 
 const Settings: FC = () => {
@@ -84,7 +107,7 @@ const Settings: FC = () => {
     saveSettings(
       values.opening_date,
       values.projects,
-      values.lists
+      values.days
     )
   }
 
@@ -106,17 +129,21 @@ const Settings: FC = () => {
                   />
                 </DateInputWrap>
               </Div>
+
               <ColumnWrap>
                 <ProjectsCheckboxes projects={data?.projects ?? []} />
               </ColumnWrap>
-              <ColumnWrap>
-                { DAY_PARTS.map((dayPartConfig, index) => <DayPartSettings
-                  key={dayPartConfig.title}
-                  index={index}
-                  stadia={data?.stadia ?? []}
-                  {...dayPartConfig}
-                />)}
-              </ColumnWrap>
+
+              { [DAY_PARTS, WEEKEND, EVENINGS].map(row => (
+                <Div>
+                  { row.map(dayPartConfig => (
+                    <DayPartSettingsWrap>
+                      <DayPartSettings key={dayPartConfig.title} stadia={data?.stadia ?? []} {...dayPartConfig} />
+                    </DayPartSettingsWrap>
+                  ))}
+                </Div>
+              )) }
+
               <ButtonWrap>
                 { errorMessage && <ErrorMessage text={ errorMessage! } /> }
                 { submitSucceeded && !dirty && !isUpdating && !errorMessage && <SuccessMessage text='Succesvol opgeslagen' /> }

--- a/src/components/planning/Settings.tsx
+++ b/src/components/planning/Settings.tsx
@@ -46,19 +46,25 @@ const ButtonWrap = styled.div`
   }
 `
 
-const DAY_PARTS = [
-  'Maandag',
-  'Maandag avond',
-  'Dinsdag',
-  'Dinsdag avond',
-  'Woensdag',
-  'Woensdag avond',
-  'Donderdag',
-  'Donderdag avond',
-  'Vrijdag',
-  'Vrijdag avond',
-  'Zaterdag weekend',
-  'Zondag weekend'
+export type DayPartConfig = {
+  day: Day
+  dayPart: DayPart
+  title: string
+}
+
+const DAY_PARTS:DayPartConfig[] = [
+  {day: 'monday', dayPart: 'day', title: 'Maandag'},
+  {day: 'monday', dayPart: 'evening', title: 'Maandag avond'},
+  {day: 'tuesday', dayPart: 'day', title: 'Dinsdag'},
+  {day: 'tuesday', dayPart: 'evening', title: 'Dinsdag avond'},
+  {day: 'wednesday', dayPart: 'day', title: 'Woensdag'},
+  {day: 'wednesday', dayPart: 'evening', title: 'Woensdag avond'},
+  {day: 'thursday', dayPart: 'day', title: 'Donderdag'},
+  {day: 'thursday', dayPart: 'evening', title: 'Donderdag avond'},
+  {day: 'friday', dayPart: 'day', title: 'Vrijdag'},
+  {day: 'friday', dayPart: 'evening', title: 'Vrijdag avond'},
+  {day: 'saturday', dayPart: 'day', title: 'Zaterdag weekend'},
+  {day: 'sunday', dayPart: 'day', title: 'Zondag weekend'},
 ]
 
 const Settings: FC = () => {
@@ -104,7 +110,12 @@ const Settings: FC = () => {
                 <ProjectsCheckboxes projects={data?.projects ?? []} />
               </ColumnWrap>
               <ColumnWrap>
-                { DAY_PARTS.map((day, index) => <DayPartSettings key={day} index={index} day={day} stadia={data?.stadia ?? []} />)}
+                { DAY_PARTS.map((dayPartConfig, index) => <DayPartSettings
+                  key={dayPartConfig.title}
+                  index={index}
+                  stadia={data?.stadia ?? []}
+                  {...dayPartConfig}
+                />)}
               </ColumnWrap>
               <ButtonWrap>
                 { errorMessage && <ErrorMessage text={ errorMessage! } /> }

--- a/src/config/planning.ts
+++ b/src/config/planning.ts
@@ -1,8 +1,0 @@
-// @TODO: It would be more robust to use listsWeek.name vs. slicing
-export const listsDay = (listsWeek: SettingsLists, dayOfWeek: number) => {
-  const isWeekend = dayOfWeek > 4
-  const isSunday = dayOfWeek === 6
-  const start = isSunday ? 11 : dayOfWeek * 2
-  const length = isWeekend ? 1 : 2
-  return listsWeek.slice(start, start + length)
-}

--- a/src/contexts/StateContext.ts
+++ b/src/contexts/StateContext.ts
@@ -77,7 +77,7 @@ const value = {
     planningSettingsActions: {
       initialize: noop,
       clear: noop,
-      saveSettings: (a: string, b: string[], c: SettingsLists) => {}
+      saveSettings: (a: string, b: string[], c: SettingsListMap) => {}
     },
 
     users: usersState,

--- a/src/lib/utils/day.ts
+++ b/src/lib/utils/day.ts
@@ -1,0 +1,12 @@
+const DAYS:Day[] = [
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday"
+]
+
+export const getCurrentDay = ():Day =>
+  DAYS[new Date().getDay() - 1]

--- a/src/state/useItineraries.ts
+++ b/src/state/useItineraries.ts
@@ -62,11 +62,12 @@ const useItineraries = () : [ItinerariesState, ItinerariesActions, ItinerariesSe
         opening_date: settings.opening_date,
         target_length: num,
         projects: settings.projects.map((item: string) => ({ name: item })),
-        primary_stadium: settings.lists.primary_stadium ? { name: settings.lists.primary_stadium } : undefined,
-        secondary_stadia: settings.lists.secondary_stadia ? settings.lists.secondary_stadia.map((stadium: Stadium) => ({ name: stadium })) : undefined,
-        exclude_stadia: settings.lists.exclude_stadia ? settings.lists.exclude_stadia.map((stadium: Stadium) => ({ name: stadium })) : undefined
+        primary_stadium: settings.days.primary_stadium ? { name: settings.days.primary_stadium } : undefined,
+        secondary_stadia: settings.days.secondary_stadia ? settings.days.secondary_stadia.map((stadium: Stadium) => ({ name: stadium })) : undefined,
+        exclude_stadia: settings.days.exclude_stadia ? settings.days.exclude_stadia.map((stadium: Stadium) => ({ name: stadium })) : undefined
       }
     }
+
     const [response, result, errorMessage = "Failed to GET"] = await post(url, body)
     dispatch(createStopFetching())
     if (isForbidden(response)) {

--- a/src/state/usePlanningSettings.ts
+++ b/src/state/usePlanningSettings.ts
@@ -44,12 +44,12 @@ const usePlanningSettings = () : [PlanningSettingsState, PlanningSettingsActions
     dispatch(createClear())
   }, [dispatch])
 
-  const saveSettings = useCallback(async (openingDate: string, projects: Projects, lists: SettingsLists) => {
+  const saveSettings = useCallback(async (openingDate: string, projects: Projects, days: SettingsListMap) => {
     const { data } = state
     if (data === undefined) return
     const { settings: prevSettings } = data
     if (prevSettings === undefined) return
-    const settings = { ...prevSettings, opening_date: openingDate, projects, lists }
+    const settings = { ...prevSettings, opening_date: openingDate, projects, days }
     dispatch(createStartUpdating())
     const [response, result, errorMessage] = await post(getUrl("settings/planner"), settings)
     if (notOk(response)) return dispatch(createSetError(errorMessage || "Opslaan mislukt"))

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -232,20 +232,21 @@ declare type Day =
 declare type DayPart = "day" | "evening"
 
 declare type SettingsList = {
-  day: Day
-  dayPart: DayPart
   name: string
   primary_stadium?: Stadium
   secondary_stadia?: Stadia
   exclude_stadia?: Stadia
 }
-declare type SettingsLists = SettingsList[]
+
+// { monday: { evening: { name: '...',  primary_stadium: '...', ... } } }
+declare type SettingsListMap = Record<Day, Record<DayPart, SettingsList>>
+
 declare type Project = string
 declare type Projects = Project[]
 declare type PlanningSettings = {
   opening_date: string
   projects: Projects
-  lists: SettingsLists
+  days:SettingsListMap
 }
 declare type PlanningSettingsData = {
   projects: string[]

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -220,7 +220,20 @@ declare type PlanningResult = {
   data?: PlanningData
 }
 
+declare type Day =
+  | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday"
+  | "sunday"
+
+declare type DayPart = "day" | "evening"
+
 declare type SettingsList = {
+  day: Day
+  dayPart: DayPart
   name: string
   primary_stadium?: Stadium
   secondary_stadia?: Stadia


### PR DESCRIPTION
`PlanningSettingsLists` is now defined as: 
`Record<Day, Record<DayPart, PlanningSettingList>>`

It allowed me to easily shuffle lists in the view.

Example:
```
 "days": {
    "monday": {
      "day": { ... },
      "evening": { ... }
    },
   "tuesday": {
      "day": { ... },
      "evening": { ... }
   }
}
```

Backend is updated, and UX agreed with the design