### PR TITLE
Autogenerated API types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # production
 /build
 
+#generated
+__generated__
+
 # misc
 .DS_Store
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@
 # production
 /build
 
-#generated
-__generated__
-
 # misc
 .DS_Store
 .env.local

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@
 ## development
 
 Run:
-- `npm run swagger:generate-schema` or `npm run swagger:generate-schema:acc` to fetch the latest API-schemas.
+- `git clone https://github.com/Amsterdam/fixxx-looplijsten-frontend.git`
+- `cd fixxx-looplijsten-frontend`
+- `npm install`
+- `npm run swagger:generate-schema:acc` to fetch the latest API-schemas
 
 Connect to acceptance backend
 - `npm run start:acc`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 
 ## development
 
+Run:
+- `npm run swagger:generate-schema` or `npm run swagger:generate-schema:acc` to fetch the latest API-schemas.
+
 Connect to acceptance backend
 - `npm run start:acc`
 - open `http://localhost:3001/` in browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -10411,6 +10411,16 @@
         "warning": "^4.0.3"
       }
     },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -11240,6 +11250,49 @@
       "dev": true,
       "requires": {
         "dotenv-defaults": "^1.0.2"
+      }
+    },
+    "dtsgenerator": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/dtsgenerator/-/dtsgenerator-2.5.1.tgz",
+      "integrity": "sha512-+/pJkx59oJuUo0wutbJoqiJaLes4i3ksLftbUwqZHbUjqYtNWu5YbM1Zouk3q52OLS0+Sbzihlwv1VQIdp7H7A==",
+      "dev": true,
+      "requires": {
+        "commander": "^5.1.0",
+        "cross-fetch": "^3.0.4",
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "^1.0.4",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
       }
     },
     "duplexer": {

--- a/package.json
+++ b/package.json
@@ -61,8 +61,9 @@
     "lint:quiet": "npm run lint -- --quiet",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009 -s public",
-    "build-storybook": "build-storybook -s public",
-    "swagger:generate-schema": "dtsgen -o ./src/__generated__/apiSchema.d.ts -n API --url https://acc.api.top.amsterdam.nl/api/v1/swagger/?format=openapi"
+    "storybook:build": "build-storybook -s public",
+    "swagger:generate-schema:acc": "dtsgen -o ./src/__generated__/apiSchema.d.ts -n API --url https://acc.api.top.amsterdam.nl/api/v1/swagger/?format=openapi",
+    "swagger:generate-schema": "dtsgen -o ./src/__generated__/apiSchema.d.ts -n API --url https://api.top.amsterdam.nl/api/v1/swagger/?format=openapi"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/react-dom": "^16.9.6",
     "@types/smoothscroll-polyfill": "^0.3.1",
     "@types/styled-components": "^5.1.0",
+    "dtsgenerator": "^2.5.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "husky": "^4.2.5",
@@ -60,7 +61,8 @@
     "lint:quiet": "npm run lint -- --quiet",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009 -s public",
-    "build-storybook": "build-storybook -s public"
+    "build-storybook": "build-storybook -s public",
+    "swagger:generate-schema": "dtsgen -o ./src/__generated__/apiSchema.d.ts -n API --url https://acc.api.top.amsterdam.nl/api/v1/swagger/?format=openapi"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/__generated__/apiSchema.d.ts
+++ b/src/__generated__/apiSchema.d.ts
@@ -1,0 +1,455 @@
+declare namespace API {
+    /**
+     * Case
+     */
+    export type Case = {
+        /**
+         * ID
+         */
+        readonly id?: number
+        /**
+         * Case id
+         */
+        case_id?: string
+        /**
+         * Bwv data
+         */
+        readonly bwv_data?: string
+        fraud_prediction?: API.FraudPrediction
+    }
+    /**
+     * Start case
+     */
+    export type CaseSimple = {
+        /**
+         * Case id
+         */
+        case_id?: string
+    }
+    /**
+     * Fraud prediction
+     */
+    export type FraudPrediction = {
+        /**
+         * Fraud probability
+         */
+        fraud_probability: number
+        /**
+         * Fraud prediction
+         */
+        fraud_prediction: boolean
+        /**
+         * Business rules
+         */
+        business_rules: {
+        }
+        /**
+         * Shap values
+         */
+        shap_values: {
+        }
+        /**
+         * Sync date
+         */
+        readonly sync_date?: string // date-time
+    }
+    namespace ItinerariesCreate {
+        export type BodyParameters = {
+            data: API.ItinerariesCreate.Parameters.Data
+        }
+        namespace Parameters {
+            export type Data = API.Itinerary;
+        }
+        namespace Responses {
+            export type $201 = API.Itinerary;
+        }
+    }
+    namespace ItinerariesList {
+        namespace Responses {
+            export type $200 = {
+                count: number
+                next?: string // uri
+                previous?: string // uri
+                results: API.Itinerary[]
+            }
+        }
+    }
+    namespace ItinerariesSuggestions {
+        namespace Responses {
+            export type $200 = API.Itinerary;
+        }
+    }
+    namespace ItinerariesTeamRead {
+        namespace Responses {
+            export type $200 = API.Itinerary;
+        }
+    }
+    namespace ItinerariesTeamUpdate {
+        export type BodyParameters = {
+            data: API.ItinerariesTeamUpdate.Parameters.Data
+        }
+        namespace Parameters {
+            export type Data = API.Itinerary;
+        }
+        namespace Responses {
+            export type $200 = API.Itinerary;
+        }
+    }
+    export type Itinerary = {
+        /**
+         * ID
+         */
+        readonly id?: number
+        /**
+         * Created at
+         */
+        readonly created_at?: string // date
+        team_members: API.ItineraryTeamMember[]
+        readonly items?: API.ItineraryItem[]
+        settings?: API.ItinerarySettings
+    }
+    export type ItineraryItem = {
+        /**
+         * ID
+         */
+        readonly id?: number
+        /**
+         * Position
+         */
+        position: number
+        readonly notes?: API.Note[]
+        case?: API.Case
+        /**
+         * Checked
+         */
+        checked?: boolean
+    }
+    export type ItineraryItemCreate = {
+        /**
+         * Itinerary
+         */
+        itinerary: number
+        /**
+         * Case id
+         */
+        case_id: string
+        /**
+         * Position
+         */
+        position?: number
+    }
+    export type ItineraryItemUpdate = {
+        /**
+         * ID
+         */
+        readonly id?: number
+        /**
+         * Position
+         */
+        position?: number
+        /**
+         * Checked
+         */
+        checked?: boolean
+    }
+    namespace ItineraryItemsCreate {
+        export type BodyParameters = {
+            data: API.ItineraryItemsCreate.Parameters.Data
+        }
+        namespace Parameters {
+            export type Data = API.ItineraryItemCreate;
+        }
+        namespace Responses {
+            export type $201 = API.ItineraryItemCreate;
+        }
+    }
+    namespace ItineraryItemsPartialUpdate {
+        export type BodyParameters = {
+            data: API.ItineraryItemsPartialUpdate.Parameters.Data
+        }
+        namespace Parameters {
+            export type Data = API.ItineraryItemUpdate;
+        }
+        namespace Responses {
+            export type $200 = API.ItineraryItemUpdate;
+        }
+    }
+    namespace ItineraryItemsUpdate {
+        export type BodyParameters = {
+            data: API.ItineraryItemsUpdate.Parameters.Data
+        }
+        namespace Parameters {
+            export type Data = API.ItineraryItemUpdate;
+        }
+        namespace Responses {
+            export type $200 = API.ItineraryItemUpdate;
+        }
+    }
+    /**
+     * Settings
+     */
+    export type ItinerarySettings = {
+        /**
+         * Opening date
+         */
+        opening_date: string // date
+        /**
+         * Target length
+         */
+        target_length?: number
+        projects: API.Project[]
+        primary_stadium: API.Stadium
+        secondary_stadia: API.Stadium[]
+        exclude_stadia: API.Stadium[]
+        start_case?: API.CaseSimple
+        /**
+         * Postal code range start
+         */
+        postal_code_range_start?: number
+        /**
+         * Postal code range end
+         */
+        postal_code_range_end?: number
+    }
+    export type ItineraryTeamMember = {
+        /**
+         * ID
+         */
+        readonly id?: number
+        user?: API.UserId
+    }
+    export type Note = {
+        /**
+         * ID
+         */
+        readonly id?: number
+        /**
+         * Text
+         */
+        text: string
+        author?: API.User
+    }
+    export type NoteCrud = {
+        /**
+         * ID
+         */
+        readonly id?: number
+        /**
+         * Text
+         */
+        text: string
+        /**
+         * Itinerary item
+         */
+        itinerary_item: number
+        author?: API.User
+    }
+    namespace NotesCreate {
+        export type BodyParameters = {
+            data: API.NotesCreate.Parameters.Data
+        }
+        namespace Parameters {
+            export type Data = API.NoteCrud;
+        }
+        namespace Responses {
+            export type $201 = API.NoteCrud;
+        }
+    }
+    namespace NotesPartialUpdate {
+        export type BodyParameters = {
+            data: API.NotesPartialUpdate.Parameters.Data
+        }
+        namespace Parameters {
+            export type Data = API.NoteCrud;
+        }
+        namespace Responses {
+            export type $200 = API.NoteCrud;
+        }
+    }
+    namespace NotesRead {
+        namespace Responses {
+            export type $200 = API.NoteCrud;
+        }
+    }
+    namespace NotesUpdate {
+        export type BodyParameters = {
+            data: API.NotesUpdate.Parameters.Data
+        }
+        namespace Parameters {
+            export type Data = API.NoteCrud;
+        }
+        namespace Responses {
+            export type $200 = API.NoteCrud;
+        }
+    }
+    /**
+     * Monday
+     */
+    export type PlannerDaySettings = {
+        day?: API.PlannerListSettings
+        evening?: API.PlannerListSettings
+    }
+    /**
+     * Day
+     */
+    export type PlannerListSettings = {
+        /**
+         * Length of list
+         */
+        length_of_list?: number
+        /**
+         * Primary stadium
+         */
+        primary_stadium?: "Onderzoek buitendienst" | "2de Controle" | "3de Controle" | "Hercontrole" | "2de hercontrole" | "3de hercontrole" | "Avondronde" | "Onderzoek advertentie" | "Weekend buitendienstonderzoek" | "Issuemelding"
+        secondary_stadia?: ("Onderzoek buitendienst" | "2de Controle" | "3de Controle" | "Hercontrole" | "2de hercontrole" | "3de hercontrole" | "Avondronde" | "Onderzoek advertentie" | "Weekend buitendienstonderzoek" | "Issuemelding")[]
+        exclude_stadia?: ("Onderzoek buitendienst" | "2de Controle" | "3de Controle" | "Hercontrole" | "2de hercontrole" | "3de hercontrole" | "Avondronde" | "Onderzoek advertentie" | "Weekend buitendienstonderzoek" | "Issuemelding")[]
+    }
+    /**
+     * Postal code
+     */
+    export type PlannerPostalCodeSettings = {
+        /**
+         * Range start
+         */
+        range_start: number
+        /**
+         * Range end
+         */
+        range_end: number
+    }
+    export type PlannerSettings = {
+        /**
+         * Opening date
+         */
+        opening_date: string // date
+        projects: ("Bed en breakfast 2019" | "Burgwallenproject Oudezijde" | "Corpo-rico" | "Digital toezicht Safari" | "Digital toezicht Zebra" | "Haarlemmerbuurt" | "Hotline" | "Mystery Guest" | "Project Andes" | "Project Jordaan" | "Project Lobith" | "Project Sahara" | "Safari" | "Safari 2015" | "Sahara Adams Suites" | "Sahara hele woning" | "Sahara meer dan 4" | "Sahara Recensies" | "Sahara veel adv" | "Social Media 2019" | "Woonschip (woonboot)" | "Zebra")[]
+        postal_code?: API.PlannerPostalCodeSettings
+        days: API.PlannerWeekSettings
+    }
+    /**
+     * Days
+     */
+    export type PlannerWeekSettings = {
+        monday: API.PlannerDaySettings
+        tuesday: API.PlannerDaySettings
+        wednesday: API.PlannerDaySettings
+        thursday: API.PlannerDaySettings
+        friday: API.PlannerDaySettings
+        saturday: API.PlannerDaySettings
+        sunday: API.PlannerDaySettings
+    }
+    export type Project = {
+        /**
+         * Name
+         */
+        name: "Bed en breakfast 2019" | "Burgwallenproject Oudezijde" | "Corpo-rico" | "Digital toezicht Safari" | "Digital toezicht Zebra" | "Haarlemmerbuurt" | "Hotline" | "Mystery Guest" | "Project Andes" | "Project Jordaan" | "Project Lobith" | "Project Sahara" | "Safari" | "Safari 2015" | "Sahara Adams Suites" | "Sahara hele woning" | "Sahara meer dan 4" | "Sahara Recensies" | "Sahara veel adv" | "Social Media 2019" | "Woonschip (woonboot)" | "Zebra"
+    }
+    namespace SearchList {
+        namespace Responses {
+            export type $200 = {
+                count: number
+                next?: string // uri
+                previous?: string // uri
+                results: API.Case[]
+            }
+        }
+    }
+    namespace SettingsPlannerCreate {
+        export type BodyParameters = {
+            data: API.SettingsPlannerCreate.Parameters.Data
+        }
+        namespace Parameters {
+            export type Data = API.PlannerSettings;
+        }
+        namespace Responses {
+            export type $201 = API.PlannerSettings;
+        }
+    }
+    namespace SettingsPlannerList {
+        namespace Responses {
+            export type $200 = {
+                count: number
+                next?: string // uri
+                previous?: string // uri
+                results: API.PlannerSettings[]
+            }
+        }
+    }
+    /**
+     * Primary stadium
+     */
+    export type Stadium = {
+        /**
+         * Name
+         */
+        name: "Onderzoek buitendienst" | "2de Controle" | "3de Controle" | "Hercontrole" | "2de hercontrole" | "3de hercontrole" | "Avondronde" | "Onderzoek advertentie" | "Weekend buitendienstonderzoek" | "Issuemelding"
+    }
+    /**
+     * Author
+     */
+    export type User = {
+        /**
+         * Id
+         */
+        id: string // uuid
+        /**
+         * Email
+         */
+        email: string // email
+        /**
+         * Username
+         */
+        username: string
+        /**
+         * First name
+         */
+        first_name: string
+        /**
+         * Last name
+         */
+        last_name: string
+        /**
+         * Full name
+         */
+        full_name: string
+    }
+    /**
+     * User
+     */
+    export type UserId = {
+        /**
+         * Id
+         */
+        id: string // uuid
+        /**
+         * Email
+         */
+        readonly email?: string // email
+        /**
+         * Username
+         */
+        readonly username?: string
+        /**
+         * First name
+         */
+        readonly first_name?: string
+        /**
+         * Last name
+         */
+        readonly last_name?: string
+        /**
+         * Full name
+         */
+        full_name: string
+    }
+    namespace UsersList {
+        namespace Responses {
+            export type $200 = {
+                count: number
+                next?: string // uri
+                previous?: string // uri
+                results: API.User[]
+            }
+        }
+    }
+}

--- a/src/components/itineraries/Generate/Generate.tsx
+++ b/src/components/itineraries/Generate/Generate.tsx
@@ -15,7 +15,7 @@ export type GenerateItineraryFormValues = {
   projects: Projects
   postalCodeRange: PostalCodeRange
   numAddresses: number
-  dayPart: { label: string, settingsList: SettingsList }
+  dayPart: { label: string, settingsList?: API.PlannerListSettings }
   users: User[]
   startAddress?: CaseId
 }

--- a/src/components/itineraries/Generate/util/getDayPartOptions.tsx
+++ b/src/components/itineraries/Generate/util/getDayPartOptions.tsx
@@ -1,9 +1,9 @@
 import getCurrentDay from "../../../../lib/utils/day"
 import isWeekDay from "../../../../lib/utils/isWeekDay"
 
-export const getDayPartOptions = (settings: PlanningSettings) => {
+export const getDayPartOptions = (settings: API.PlannerSettings) => {
   const currentDay = settings.days[getCurrentDay()]
   return isWeekDay()
-    ? [ { label: "daglijst", settingsList: currentDay?.day }, { label: "avondlijst", settingsList: currentDay?.evening } ]
-    : [ { label: "weekend", settingsList: currentDay?.day } ]
+    ? [ { label: "daglijst", settingsList: currentDay.day }, { label: "avondlijst", settingsList: currentDay.evening } ]
+    : [ { label: "weekend", settingsList: currentDay.day } ]
 }

--- a/src/components/planning/DayPartSettings.tsx
+++ b/src/components/planning/DayPartSettings.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import { CheckboxFields, combineValidators, isNotIntersectingWith, SelectField } from "amsterdam-react-final-form"
 import { AccordionWrapper, Accordion, themeColor, themeSpacing } from "@datapunt/asc-ui"
 import { arrayToObject } from "../../lib/arrayToObject"
+import { Day, DayPart } from "../../lib/utils/day"
 
 type Props = {
   title: string

--- a/src/components/planning/Settings.tsx
+++ b/src/components/planning/Settings.tsx
@@ -18,6 +18,7 @@ import SmallSpinner from "../global/SmallSpinner"
 import Spinner from "../global/Spinner"
 import Box from "../atoms/Box/Box"
 import { arrayToObject } from "../../lib/arrayToObject"
+import { Day, DayPart } from "../../lib/utils/day"
 
 const Wrap = styled.div`
   margin-bottom: 100px;
@@ -115,20 +116,10 @@ const Settings: FC = () => {
     }
   } = useGlobalState()
 
-
-  const onSubmit = (values: PlanningSettings) => {
-    saveSettings(
-      values.opening_date,
-      values.projects,
-      values.days,
-      values.postal_code
-    )
-  }
-
   return isFetching
   ? <Spinner />
   : <Form
-      onSubmit={onSubmit}
+      onSubmit={saveSettings}
       initialValues={data?.settings}
       render={({ handleSubmit, values, hasValidationErrors, submitSucceeded, dirty }) => (
          <Wrap>

--- a/src/contexts/StateContext.ts
+++ b/src/contexts/StateContext.ts
@@ -77,7 +77,7 @@ const value = {
     planningSettingsActions: {
       initialize: noop,
       clear: noop,
-      saveSettings: (a: string, b: string[], c: SettingsListMap) => {}
+      saveSettings: (a: API.PlannerSettings) => {}
     },
 
     users: usersState,

--- a/src/lib/utils/day.ts
+++ b/src/lib/utils/day.ts
@@ -1,4 +1,7 @@
-const DAYS: Days = [
+export type Day = keyof API.PlannerWeekSettings
+export type DayPart = keyof API.PlannerDaySettings
+
+const DAYS: Day[] = [
   "sunday",
   "monday",
   "tuesday",

--- a/src/state/useItineraries.ts
+++ b/src/state/useItineraries.ts
@@ -59,7 +59,7 @@ const useItineraries = (): [ItinerariesState, ItinerariesActions, ItinerariesSel
       startAddress,
       numAddresses,
       dayPart: {
-        settingsList: { primary_stadium, secondary_stadia, exclude_stadia }
+        settingsList
       }
     } = values
 
@@ -79,9 +79,9 @@ const useItineraries = (): [ItinerariesState, ItinerariesActions, ItinerariesSel
         opening_date: openingsDate,
         target_length: numAddresses,
         projects: wrapInNameObjects(projects),
-        primary_stadium:  wrapInNameObject(primary_stadium),
-        secondary_stadia: wrapInNameObjects(secondary_stadia),
-        exclude_stadia: wrapInNameObjects(exclude_stadia)
+        primary_stadium:  wrapInNameObject(settingsList?.primary_stadium),
+        secondary_stadia: wrapInNameObjects(settingsList?.secondary_stadia),
+        exclude_stadia: wrapInNameObjects(settingsList?.exclude_stadia)
       }
     }
 

--- a/src/state/usePlanningSettings.ts
+++ b/src/state/usePlanningSettings.ts
@@ -44,12 +44,12 @@ const usePlanningSettings = (): [PlanningSettingsState, PlanningSettingsActions]
     dispatch(createClear())
   }, [dispatch])
 
-  const saveSettings = useCallback(async (openingDate: string, projects: Projects, days: SettingsListMap, postalCode: PostalCodeRange) => {
+  const saveSettings = useCallback(async (values: API.PlannerSettings) => {
     const { data } = state
     if (data === undefined) return
     const { settings: prevSettings } = data
     if (prevSettings === undefined) return
-    const settings = { ...prevSettings, opening_date: openingDate, projects, days, postal_code: postalCode }
+    const settings = { ...prevSettings, ...values }
     dispatch(createStartUpdating())
     const [response, result, errorMessage] = await post(getUrl("settings/planner"), settings)
     if (notOk(response)) return dispatch(createSetError(errorMessage || "Opslaan mislukt"))

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -207,40 +207,6 @@ declare type List = {
   itineraries: BWVData[][]
 }
 declare type Lists = List[]
-declare type PlanningData = {
-  opening_date: string
-  projects: string[]
-  lists: Lists
-  unplanned_cases: BWVData[]
-}
-
-declare type PlanningResult = {
-  success: boolean
-  error?: string
-  data?: PlanningData
-}
-
-declare type Day =
-  | "monday"
-  | "tuesday"
-  | "wednesday"
-  | "thursday"
-  | "friday"
-  | "saturday"
-  | "sunday"
-declare type Days = Day[]
-
-declare type DayPart = "day" | "evening"
-
-declare type SettingsList = {
-  name: string
-  primary_stadium?: Stadium
-  secondary_stadia?: Stadia
-  exclude_stadia?: Stadia
-}
-
-// { monday: { evening: { name: '...',  primary_stadium: '...', ... } } }
-declare type SettingsListMap = Record<Day, Record<DayPart, SettingsList>>
 
 declare type Project = string
 declare type Projects = Project[]
@@ -250,15 +216,8 @@ declare type PostalCodeRange = {
   range_end: string
 }
 
-declare type PlanningSettings = {
-  opening_date: string
-  projects: Projects
-  days: SettingsListMap
-  postal_code: PostalCodeRange
-}
-
 declare type PlanningSettingsData = {
   projects: string[]
   stadia: Stadia
-  settings: PlanningSettings
+  settings: Api.PlannerSettings
 }

--- a/src/types/state.d.ts
+++ b/src/types/state.d.ts
@@ -74,7 +74,7 @@ declare type PlanningSettingsState = {
 declare type PlanningSettingsActions = {
   initialize: () => void
   clear: () => void
-  saveSettings: (a: string, b: string[], c: SettingsLists, d: PostalCodeRange) => void
+  saveSettings: (a: API.PlannerSettings) => void
 }
 
 declare type UsersState = {


### PR DESCRIPTION
- Added a type-generator to generate types based on swagger configuration.
- Replaced `Settings`-related types with the auto-generated ones.

NOTE:
As the autogenerated-types are not part of the repository, I don't think the build still succeeds.
Should we add the `swagger:generate-schema` to the build-steps?