### PR TITLE
feat: enables visit wizard

### DIFF
--- a/src/app/features/itineraries/components/pages/itinerary/mapItineraryItem.tsx
+++ b/src/app/features/itineraries/components/pages/itinerary/mapItineraryItem.tsx
@@ -19,9 +19,9 @@ import Notes from "../../molecules/Notes/Notes"
 //       : to("/lijst/:itineraryId/notities/:itineraryItemId/:noteId", { itineraryItemId: itineraryItemId.toString(), itineraryId, noteId: noteId.toString() })
 //   )
 
-export const mapItineraryItem = (itineraryId: string, userId?: string) => ({ id, position, notes, case: { case_id, fraud_prediction, bwv_data: { street_name, street_number, suffix_letter, suffix, postal_code, case_reason, stadium } } }: ItineraryItem) => {
+export const mapItineraryItem = (itineraryId: string, userId?: string) => ({ id, position, notes, case: { case_id, fraud_prediction, bwv_data: { street_name, street_number, suffix_letter, suffix, postal_code, case_reason, stadium } } }: ItineraryItem) => 
   //const note = notes.find(_ => _.author.id === userId)
-  return ({
+   ({
     href: to("/lijst/:itineraryId/cases/:id", { itineraryId, id: case_id ?? "" }),
     position,
     id: case_id!,
@@ -43,4 +43,4 @@ export const mapItineraryItem = (itineraryId: string, userId?: string) => ({ id,
       ? <Notes notes={notes} />
       : undefined
   })
-}
+

--- a/src/app/features/itineraries/components/pages/itinerary/mapItineraryItem.tsx
+++ b/src/app/features/itineraries/components/pages/itinerary/mapItineraryItem.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { navigate } from "@reach/router"
-import { Document } from "@datapunt/asc-assets"
+import { Button } from "@datapunt/asc-ui"
 
 import FraudProbability from "app/features/shared/components/atoms/FraudProbability/FraudProbability"
 import StadiumBadge from "app/features/shared/components/molecules/StadiumBadge/StadiumBadge"
@@ -9,19 +9,18 @@ import Spacing from "app/features/shared/components/atoms/Spacing/Spacing"
 import to from "app/features/shared/routing/to"
 
 import DeleteItineraryItemButton from "app/features/itineraries/components/molecules/DeleteItineraryItemButton/DeleteItineraryItemButton"
-import StyledButton from "app/features/shared/components/atoms/StyledButton/StyledButton"
 
 import { ItineraryItem } from "app/features/types"
 import Notes from "../../molecules/Notes/Notes"
 
-const handleClick = (itineraryItemId: number, itineraryId: string, noteId?: number) => navigate(
-    noteId === undefined
-      ? to("/lijst/:itineraryId/notities/:itineraryItemId/nieuw", { itineraryItemId: itineraryItemId.toString(), itineraryId })
-      : to("/lijst/:itineraryId/notities/:itineraryItemId/:noteId", { itineraryItemId: itineraryItemId.toString(), itineraryId, noteId: noteId.toString() })
-  )
+// const handleClick = (itineraryItemId: number, itineraryId: string, noteId?: number) => navigate(
+//     noteId === undefined
+//       ? to("/lijst/:itineraryId/notities/:itineraryItemId/nieuw", { itineraryItemId: itineraryItemId.toString(), itineraryId })
+//       : to("/lijst/:itineraryId/notities/:itineraryItemId/:noteId", { itineraryItemId: itineraryItemId.toString(), itineraryId, noteId: noteId.toString() })
+//   )
 
 export const mapItineraryItem = (itineraryId: string, userId?: string) => ({ id, position, notes, case: { case_id, fraud_prediction, bwv_data: { street_name, street_number, suffix_letter, suffix, postal_code, case_reason, stadium } } }: ItineraryItem) => {
-  const note = notes.find(_ => _.author.id === userId)
+  //const note = notes.find(_ => _.author.id === userId)
   return ({
     href: to("/lijst/:itineraryId/cases/:id", { itineraryId, id: case_id ?? "" }),
     position,
@@ -34,7 +33,7 @@ export const mapItineraryItem = (itineraryId: string, userId?: string) => ({ id,
     fraudProbability: <FraudProbability fraudProbability={fraud_prediction?.fraud_probability} />,
     buttons: <>
       <Spacing pb={2}>
-          <StyledButton onClick={() => handleClick(id, itineraryId, note?.id)} variant="blank" icon={<Document />} />
+        <Button variant="secondary" onClick={() => navigate(to("/visit/:itineraryId/:caseId", { caseId: case_id, itineraryId: itineraryId }))}>Bezoek</Button>
       </Spacing>
       <Spacing pb={2}>
         <DeleteItineraryItemButton id={id}/>

--- a/src/app/features/visits/components/pages/WizardPage.tsx
+++ b/src/app/features/visits/components/pages/WizardPage.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+
+import NoteWizardModal from "../organisms/NoteWizard/NoteWizardModal"
+
+const WizardPage: React.FC = () => (<NoteWizardModal />)
+
+export default WizardPage

--- a/src/app/features/visits/routes.ts
+++ b/src/app/features/visits/routes.ts
@@ -1,6 +1,8 @@
+import WizardPage from "./components/pages/WizardPage"
 import NotePage from "./components/pages/NotePage"
 
 export default {
+  "/visit/:itineraryId/:caseId": WizardPage,
   "/lijst/:itineraryId/notities/:itineraryItemId/nieuw": NotePage,
   "/lijst/:itineraryId/notities/:itineraryItemId/:noteId": NotePage
 }


### PR DESCRIPTION
# MAJOR CLEANUP

Decided to execute a major cleanup after I had to modify a lot of boilerplate code (managing state) to implement the new feature "visit wizard", which I think will only increase whenever we add more features to TOP.

Hope you're not too overwhelmed by it :-).

## How to check:

Please checkout "feature/major-clean-up", run a `npm i`, and then `npm run start` to review.

## Pros

### 1. Folder structure same as ZaakSysteem
- Easy to reuse concepts in both repositories
- One way of working.
- Split code into features:
  - `cases`
  - `itineraries`
  - `login`
  - `settings`
  - `shared`
  - `visits`

### 2. Typesafe routes
Same solution as `Zaaksysteem` - frontend

### 3. Less code
~25% less lines of code in `ts` and `tsx` files. (Approx. 2000 Lines of code less)

### 4. Use generated types from Swagger schema.
As much as possible. (Not all responses are documented correctly).
When the backend is ready, switching to it completely is not that hard anymore.

### 5 Reusable ItineraryItemCard/ItineraryItemCardList
- Introduced a generic ItineraryItemCard/ItineraryItemCardList used by:
	 - itineraries
	 - suggestions
	 - open-issues
	 - start-address

### 6 Introduced environment variables
No runtime checks anymore

### 7 Replaced `useGlobalState` with `useApiRequest`

- Added options for useApiRequest:
      - `lazy` (boolean): When true: don't fetch data on mount.
            - example: `useItineraries({ lazy: true })`   
		
- Added options for `execDelete`, `execPost`, `execPut`, `execPatch`:
     - `skipCacheClear` (boolean): When true, cache won't get cleared
           - example: `const { execPatch } =  useItineraries({ lazy: true }); execPatch({ skipCacheClear: true })`
    - `useResponseAsCache` (boolean). When true, cache will be populated with the response of this request.
           - example: `const { execPatch } =  useItineraries({ lazy: true }); execPatch({ useResponseAsCache: true })`
             		
- Added posibility to update cache manually: eg: 

```
const { updateCache } = useItineraries(); updateCache(( itineraries ) => {
// do something with itineraries 
})
```
		
- Easier to reason with, as latest API response is automatically fetched and used, there is no need to update state manually.


## Cons:

- LOTS of changes
- Spinner is shown shortly when adding/deleting an item to a list. (Because cache is being cleared, and we refetch again automatically). 
However, dragging items around wont trigger a spinner as we can safely update the cache here.