### PR TITLE
Top 46 space in postal code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .env.test.local
 .env.production.local
 .eslintcache
+.idea/
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/app/features/itineraries/components/organisms/SearchResults/SearchResults.tsx
+++ b/src/app/features/itineraries/components/organisms/SearchResults/SearchResults.tsx
@@ -16,7 +16,8 @@ type Props = {
 const SearchResults: React.FC<Props> = ({ postalCode, streetNumber, suffix }) => {
   const { itineraryId } = useParams()
   const { data: itinerary } = useItinerary(itineraryId!)
-  const { data, isBusy } = useSearch(postalCode, streetNumber, suffix)
+  const postalCodeTrimmed = postalCode.replace(/\s+/g, "")
+  const { data, isBusy } = useSearch(postalCodeTrimmed, streetNumber, suffix)
 
   const items = useMemo(() => casesToCardCaseProps(data?.cases, itinerary), [itinerary, data])
 


### PR DESCRIPTION
This strips inner whitespace – from the `postalCode` only, not from other fields which could also have spaces – before adding it to the rest url query string.

The `.gitignore` commit will nicely disappear if this PR gets merged after the `webstorm-gitignore` one.