### PR TITLE
Feature: zaken zoeken op straatnaam

### DIFF
--- a/src/app/features/itineraries/components/organisms/SearchResults/SearchResults.tsx
+++ b/src/app/features/itineraries/components/organisms/SearchResults/SearchResults.tsx
@@ -17,7 +17,7 @@ type Props = {
 const SearchResults: React.FC<Props> = ({ postalCode, streetName, streetNumber, suffix }) => {
   const { itineraryId } = useParams()
   const { data: itinerary } = useItinerary(itineraryId!)
-  const postalCodeTrimmed = postalCode.replace(/\s+/g, "")
+  const postalCodeTrimmed = postalCode?.replace(/\s+/g, "")
   const { data, isBusy } = useSearch(streetNumber, postalCodeTrimmed, streetName, suffix)
 
   const items = useMemo(() => casesToCardCaseProps(data?.cases, itinerary), [itinerary, data])

--- a/src/app/features/itineraries/components/organisms/SearchResults/SearchResults.tsx
+++ b/src/app/features/itineraries/components/organisms/SearchResults/SearchResults.tsx
@@ -8,16 +8,17 @@ import { casesToCardCaseProps } from "app/features/itineraries/utils/mapCaseToCa
 import ItineraryItemCardList from "app/features/itineraries/components/organisms/ItineraryItemCardList/ItineraryItemCardList"
 
 type Props = {
-  postalCode: string
+  postalCode?: string
+  streetName?: string
   streetNumber: number
   suffix?: string
 }
 
-const SearchResults: React.FC<Props> = ({ postalCode, streetNumber, suffix }) => {
+const SearchResults: React.FC<Props> = ({ postalCode, streetName, streetNumber, suffix }) => {
   const { itineraryId } = useParams()
   const { data: itinerary } = useItinerary(itineraryId!)
   const postalCodeTrimmed = postalCode.replace(/\s+/g, "")
-  const { data, isBusy } = useSearch(postalCodeTrimmed, streetNumber, suffix)
+  const { data, isBusy } = useSearch(streetNumber, postalCodeTrimmed, streetName, suffix)
 
   const items = useMemo(() => casesToCardCaseProps(data?.cases, itinerary), [itinerary, data])
 

--- a/src/app/features/shared/components/form/AddressPicker/components/StartAddressSearchResults/StartAddressSearchResults.tsx
+++ b/src/app/features/shared/components/form/AddressPicker/components/StartAddressSearchResults/StartAddressSearchResults.tsx
@@ -34,7 +34,7 @@ const mapResults = (handleAdd: HandleAddCallback, getUrl: (string: string) => st
   buttons: () => <StyledButton icon={<Enlarge />} onClick={() => handleAdd(case_id)} />
 })
 
-const StartAddressSearchResults: React.FC<Props> = ({ handleAddButtonClick, postalCode, streetName, streetNumber, suffix}) => {
+const StartAddressSearchResults: React.FC<Props> = ({ handleAddButtonClick, postalCode, streetName, streetNumber, suffix }) => {
   const { data, isBusy } = useSearch(streetNumber, postalCode, streetName, suffix)
   const { getUrl } = useCaseModal()
 

--- a/src/app/features/shared/components/form/AddressPicker/components/StartAddressSearchResults/StartAddressSearchResults.tsx
+++ b/src/app/features/shared/components/form/AddressPicker/components/StartAddressSearchResults/StartAddressSearchResults.tsx
@@ -17,7 +17,8 @@ type HandleAddCallback = (caseId: string) => void
 
 type Props = {
   handleAddButtonClick: HandleAddCallback
-  postalCode: string
+  postalCode?: string
+  streetName?: string
   streetNumber: number
   suffix?: string
 }
@@ -33,8 +34,8 @@ const mapResults = (handleAdd: HandleAddCallback, getUrl: (string: string) => st
   buttons: () => <StyledButton icon={<Enlarge />} onClick={() => handleAdd(case_id)} />
 })
 
-const StartAddressSearchResults: React.FC<Props> = ({ postalCode, streetNumber, suffix, handleAddButtonClick }) => {
-  const { data, isBusy } = useSearch(postalCode, streetNumber, suffix)
+const StartAddressSearchResults: React.FC<Props> = ({ handleAddButtonClick, postalCode, streetName, streetNumber, suffix}) => {
+  const { data, isBusy } = useSearch(streetNumber, postalCode, streetName, suffix)
   const { getUrl } = useCaseModal()
 
   const items = useMemo(

--- a/src/app/features/shared/components/organisms/SearchForm/SearchForm.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/SearchForm.tsx
@@ -5,6 +5,7 @@ import { SearchFormContext } from "./SearchFormProvider"
 
 export type FormValues = {
   postalCode: string
+  streetName: string
   streetNumber: number
   suffix?: string
 }

--- a/src/app/features/shared/components/organisms/SearchForm/SearchForm.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/SearchForm.tsx
@@ -9,7 +9,6 @@ export type FormValues = {
   suffix?: string
 }
 
-
 const SearchForm: FC = () => {
   const { values, setValues } = useContext(SearchFormContext)
 
@@ -19,14 +18,16 @@ const SearchForm: FC = () => {
   }, [ setValues ])
 
   const scaffoldProps = useMemo(() => createDefinition(() =>
-    // @ts-ignore
-    setValues({})),
-    [setValues]
+      // @ts-ignore
+      setValues({})
+    ),
+    [ setValues ]
   )
 
-  return (<ScaffoldForm onSubmit={handleSubmit} initialValues={values}>
-    <Scaffold {...scaffoldProps} />
-  </ScaffoldForm>
+  return (
+    <ScaffoldForm onSubmit={handleSubmit} initialValues={values}>
+      <Scaffold {...scaffoldProps} />
+    </ScaffoldForm>
   )
 }
 

--- a/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
@@ -31,7 +31,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
     suffix: {
       type: "TextField",
       props: {
-        label: "Huisletter / Etage",
+        label: "Toevoeging",
         name: "suffix",
         tabIndex: 3
       }
@@ -69,12 +69,11 @@ export const createDefinition = (onResetButtonClick: () => void) => {
   // Align these fields in a grid using FormPositioner:
   return new FormPositioner(definition)
     // From mobile and bigger we align using a custom grid:
-    .setGrid("mobileS", "1fr 1fr", [
+    .setGrid("mobileS", "1fr 1fr 1fr", [
       // Grid:
-      [ "streetName", "streetName" ],
-      [ "streetNumber", "suffix" ],
-      [ "postalCode" ],
-      [ "reset", "submit" ]
+      [ "streetName", "streetName", "streetName" ],
+      [ "postalCode", "streetNumber", "suffix" ],
+      [ "reset", "submit", "submit" ]
     ])
     // From tablet and bigger we align horizontally:
     .setHorizontal("tabletM", "3fr 1fr 1fr auto auto")

--- a/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
@@ -11,7 +11,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
       props: {
         label: "Straatnaam",
         name: "streetName",
-        validate: isRequiredWhenEmpty("postalCode", "Dit veld is verplicht"),
+        validate: isRequiredWhenEmpty("postalCode", "Vul een straatnaam óf postcode in"),
         autoFocus: true,
         tabIndex: 1
       }
@@ -22,7 +22,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
         label: "Postcode",
         name: "postalCode",
         validate: combineValidators(
-          isRequiredWhenEmpty("streetName", "Dit veld is verplicht"),
+          isRequiredWhenEmpty("streetName", "Vul een postcode óf straatnaam in"),
           isMatchingRegex(/\s*[1-9][0-9]{3}\s?[a-zA-Z]{2}\s*/, "Geldige postcodes zijn: 1234AA of 1234 aa")
         ),
         tabIndex: 2

--- a/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
@@ -17,7 +17,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
     streetNumber: {
       type: "NumberField",
       props: {
-        label: "Huisnr.",
+        label: "Huisnummer",
         name: "streetNumber",
         min: "1",
         step: "1",
@@ -31,7 +31,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
     suffix: {
       type: "TextField",
       props: {
-        label: "Hslt. / etage",
+        label: "Huisletter / Etage",
         name: "suffix",
         tabIndex: 3
       }

--- a/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
@@ -79,6 +79,6 @@ export const createDefinition = (onResetButtonClick: () => void) => {
       [ "reset", "submit", "submit" ]
     ])
     // From tablet and bigger we align horizontally:
-    .setHorizontal("tabletM", "3fr 1fr 1fr auto auto")
+    .setHorizontal("tabletM", "2fr 1fr 1fr 1fr auto auto")
     .getScaffoldProps()
 }

--- a/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Close, Search } from "@datapunt/asc-assets"
 import { combineValidators, isMatchingRegex, isRequired, ScaffoldAvailableFields } from "amsterdam-react-final-form"
 import { FormPositioner, FormPositionerFields } from "amsterdam-scaffold-form/package"
+import isRequiredWhenEmpty from "./validators/isRequiredWhenEmpty"
 
 export const createDefinition = (onResetButtonClick: () => void) => {
   const definition: FormPositionerFields<ScaffoldAvailableFields> = {
@@ -10,6 +11,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
       props: {
         label: "Straatnaam",
         name: "streetName",
+        validate: isRequiredWhenEmpty("postalCode", "Dit veld is verplicht"),
         autoFocus: true,
         tabIndex: 1
       }
@@ -42,6 +44,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
         label: "Postcode",
         name: "postalCode",
         validate: combineValidators(
+          isRequiredWhenEmpty("streetName", "Dit veld is verplicht"),
           isMatchingRegex(/\s*[1-9][0-9]{3}\s?[a-zA-Z]{2}\s*/, "Geldige postcodes zijn: 1234AA of 1234 aa")
         ),
         tabIndex: 4

--- a/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
@@ -5,16 +5,12 @@ import { FormPositioner, FormPositionerFields } from "amsterdam-scaffold-form/pa
 
 export const createDefinition = (onResetButtonClick: () => void) => {
   const definition: FormPositionerFields<ScaffoldAvailableFields> = {
-    postalCode: {
+    streetName: {
       type: "TextField",
       props: {
-        label: "Postcode",
-        name: "postalCode",
+        label: "Straatnaam",
+        name: "streetName",
         autoFocus: true,
-        validate: combineValidators(
-          isRequired(),
-          isMatchingRegex(/\s*[1-9][0-9]{3}\s?[a-zA-Z]{2}\s*/, "Geldige postcodes zijn: 1234AA of 1234 aa")
-        ),
         tabIndex: 1
       }
     },
@@ -40,6 +36,17 @@ export const createDefinition = (onResetButtonClick: () => void) => {
         tabIndex: 3
       }
     },
+    postalCode: {
+      type: "TextField",
+      props: {
+        label: "Postcode",
+        name: "postalCode",
+        validate: combineValidators(
+          isMatchingRegex(/\s*[1-9][0-9]{3}\s?[a-zA-Z]{2}\s*/, "Geldige postcodes zijn: 1234AA of 1234 aa")
+        ),
+        tabIndex: 4
+      }
+    },
     reset: {
       type: "ResetButton",
       props: {
@@ -53,7 +60,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
       props: {
         alignedHorizontally: { tabletM: true },
         icon: <Search />,
-        tabIndex: 4,
+        tabIndex: 5,
         align: "right"
       }
     }
@@ -64,11 +71,12 @@ export const createDefinition = (onResetButtonClick: () => void) => {
     // From mobile and bigger we align using a custom grid:
     .setGrid("mobileS", "1fr 1fr", [
       // Grid:
-      [ "postalCode", "postalCode" ],
+      [ "streetName", "streetName" ],
       [ "streetNumber", "suffix" ],
+      [ "postalCode" ],
       [ "reset", "submit" ]
     ])
-    // From tablet and bigger we align horizontal:
+    // From tablet and bigger we align horizontally:
     .setHorizontal("tabletM", "3fr 1fr 1fr auto auto")
     .getScaffoldProps()
 }

--- a/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
@@ -1,58 +1,58 @@
 import React from "react"
 import { Close, Search } from "@datapunt/asc-assets"
-import { combineValidators, ScaffoldAvailableFields, isMatchingRegex, isRequired } from "amsterdam-react-final-form"
+import { combineValidators, isMatchingRegex, isRequired, ScaffoldAvailableFields } from "amsterdam-react-final-form"
 import { FormPositioner, FormPositionerFields } from "amsterdam-scaffold-form/package"
 
 export const createDefinition = (onResetButtonClick: () => void) => {
   const definition: FormPositionerFields<ScaffoldAvailableFields> = {
     postalCode: {
       type: "TextField",
-        props: {
+      props: {
         label: "Postcode",
-          name: "postalCode",
-          autoFocus: true,
-          validate: combineValidators(
+        name: "postalCode",
+        autoFocus: true,
+        validate: combineValidators(
           isRequired(),
           isMatchingRegex(/\s*[1-9][0-9]{3}\s?[a-zA-Z]{2}\s*/, "Geldige postcodes zijn: 1234AA of 1234 aa")
         ),
-          tabIndex: 1
+        tabIndex: 1
       }
     },
     streetNumber: {
       type: "NumberField",
-        props: {
+      props: {
         label: "Huisnr.",
-          name: "streetNumber",
-          min: "1",
-          step: "1",
-          pattern: "\\d+",
-          title: "Alleen cijfers zijn geldig",
-          hideNumberSpinner: true,
-          validate: isRequired(),
-          tabIndex: 2
+        name: "streetNumber",
+        min: "1",
+        step: "1",
+        pattern: "\\d+",
+        title: "Alleen cijfers zijn geldig",
+        hideNumberSpinner: true,
+        validate: isRequired(),
+        tabIndex: 2
       }
     },
     suffix: {
       type: "TextField",
-        props: {
+      props: {
         label: "Hslt. / etage",
-          name: "suffix",
-          tabIndex: 3
+        name: "suffix",
+        tabIndex: 3
       }
     },
     reset: {
       type: "ResetButton",
-        props: {
-          alignedHorizontally: { tabletM: true },
-          icon: <Close / >,
-          onClick: onResetButtonClick
-        }
+      props: {
+        alignedHorizontally: { tabletM: true },
+        icon: <Close />,
+        onClick: onResetButtonClick
+      }
     },
     submit: {
       type: "SubmitButton",
       props: {
         alignedHorizontally: { tabletM: true },
-        icon: <Search / >,
+        icon: <Search />,
         tabIndex: 4,
         align: "right"
       }
@@ -61,14 +61,14 @@ export const createDefinition = (onResetButtonClick: () => void) => {
 
   // Align these fields in a grid using FormPositioner:
   return new FormPositioner(definition)
-        // From mobile and bigger we align using a custom grid:
-        .setGrid("mobileS", "1fr 1fr", [
-    // Grid:
-    ["postalCode", "postalCode"],
-    ["streetNumber", "suffix"],
-    ["reset", "submit"]
-  ])
-  // From tablet and bigger we align horizontal:
-  .setHorizontal("tabletM", "3fr 1fr 1fr auto auto")
-  .getScaffoldProps()
+    // From mobile and bigger we align using a custom grid:
+    .setGrid("mobileS", "1fr 1fr", [
+      // Grid:
+      [ "postalCode", "postalCode" ],
+      [ "streetNumber", "suffix" ],
+      [ "reset", "submit" ]
+    ])
+    // From tablet and bigger we align horizontal:
+    .setHorizontal("tabletM", "3fr 1fr 1fr auto auto")
+    .getScaffoldProps()
 }

--- a/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
@@ -16,6 +16,18 @@ export const createDefinition = (onResetButtonClick: () => void) => {
         tabIndex: 1
       }
     },
+    postalCode: {
+      type: "TextField",
+      props: {
+        label: "Postcode",
+        name: "postalCode",
+        validate: combineValidators(
+          isRequiredWhenEmpty("streetName", "Dit veld is verplicht"),
+          isMatchingRegex(/\s*[1-9][0-9]{3}\s?[a-zA-Z]{2}\s*/, "Geldige postcodes zijn: 1234AA of 1234 aa")
+        ),
+        tabIndex: 2
+      }
+    },
     streetNumber: {
       type: "NumberField",
       props: {
@@ -27,7 +39,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
         title: "Alleen cijfers zijn geldig",
         hideNumberSpinner: true,
         validate: isRequired(),
-        tabIndex: 2
+        tabIndex: 3
       }
     },
     suffix: {
@@ -35,18 +47,6 @@ export const createDefinition = (onResetButtonClick: () => void) => {
       props: {
         label: "Toevoeging",
         name: "suffix",
-        tabIndex: 3
-      }
-    },
-    postalCode: {
-      type: "TextField",
-      props: {
-        label: "Postcode",
-        name: "postalCode",
-        validate: combineValidators(
-          isRequiredWhenEmpty("streetName", "Dit veld is verplicht"),
-          isMatchingRegex(/\s*[1-9][0-9]{3}\s?[a-zA-Z]{2}\s*/, "Geldige postcodes zijn: 1234AA of 1234 aa")
-        ),
         tabIndex: 4
       }
     },

--- a/src/app/features/shared/components/organisms/SearchForm/validators/isRequiredWhenEmpty.ts
+++ b/src/app/features/shared/components/organisms/SearchForm/validators/isRequiredWhenEmpty.ts
@@ -1,0 +1,14 @@
+import type { FieldState, FieldValidator } from "final-form"
+import { getIn } from "final-form"
+import { isRequired } from "amsterdam-react-final-form"
+
+type Value = number
+
+const isRequiredWhenEmpty = (other: string, message: string): FieldValidator<Value> => (value: Value, allValues: object, meta?: FieldState<Value>) => {
+  if (meta === undefined) return
+  const otherValue = getIn(allValues, other)
+  if (otherValue !== undefined) return
+  return isRequired(message)(value)
+}
+
+export default isRequiredWhenEmpty

--- a/src/app/state/rest/index.ts
+++ b/src/app/state/rest/index.ts
@@ -87,11 +87,11 @@ export const useCase = (id: number|string, options?: Options) => {
   })
 }
 
-export const useSearch = (postalCode: string, streetNumber: number, suffix?: string, options?: Options) => {
+export const useSearch = (streetNumber: number, postalCode?: string, streetName?: string, suffix?: string, options?: Options) => {
   const handleError = useErrorHandler()
   return useApiRequest<{ cases: Case[] }>({
     ...options,
-    url: makeGatewayUrl(["search"], { postalCode, streetNumber, suffix }),
+    url: makeGatewayUrl(["search"], { postalCode, streetName, streetNumber, suffix }),
     groupName: "itineraries",
     handleError,
     getHeaders


### PR DESCRIPTION
Dit maakt het mogelijk om zaken op straatnaam en huisnummer te vinden, naast de bestaande optie postcode en huistnummer. Gebruikers vinden het gemakkelijker om een straatnaam te kunnen invoeren en niet de bijbehorende postcode te hoeven zoeken.

Gevolg is dat postcode geen verplicht veld meer is, maar de combinatie van straatnaam en postcode wel. Daar is een nieuwe validator voor geschreven. Verdere wijzigingen gaan over het model en layout van het formulier en zijn vrij triviaal. Code indentation van de geraakte bestanden stond ook niet helemaal goed.

Dependency: de branch met dezelfde naam in de backend repo.