### PR TITLE
Fixes the ports

### DIFF
--- a/.env.development_local
+++ b/.env.development_local
@@ -1,6 +1,6 @@
 # GATEWAY
-REACT_APP_GATEWAY=http://localhost:8080/api/v1/
-PORT=2999
+REACT_APP_GATEWAY=http://localhost:8000/api/v1/
+PORT=3000
 
 # To login using keycloak:
 REACT_APP_KEYCLOAK_REALM=datapunt-ad-acc


### PR DESCRIPTION
This port configuration was copied from Zaken frontend recently. Running Top and Zaken locally will now fail because of conflicts in the port configurations. Top is set to 8000, while Zaken is set to 8080. This allows both to run locally simultaneously.

Check in combination with the two other fix-ports PR