### PR TITLE
Revert "Use number inputs for postal code and suffix for easier entry…

### DIFF
--- a/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
+++ b/src/app/features/shared/components/organisms/SearchForm/formDefinition.tsx
@@ -17,7 +17,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
       }
     },
     postalCode: {
-      type: "NumberField",
+      type: "TextField",
       props: {
         label: "Postcode",
         name: "postalCode",
@@ -43,7 +43,7 @@ export const createDefinition = (onResetButtonClick: () => void) => {
       }
     },
     suffix: {
-      type: "NumberField",
+      type: "TextField",
       props: {
         label: "Toevoeging",
         name: "suffix",


### PR DESCRIPTION
… on phones"

This reverts commit 0b3f496722731749a26a8b9ba1322215df392bff.
It didn’t allow to type letters at all, which are required for postal codes and maybe for suffix as well.

Reverts #680. 