### PR TITLE
Use unfiltered options (possible non-unique values)

### DIFF
--- a/src/app/features/itineraries/components/organisms/ItineraryForm/ItineraryForm.tsx
+++ b/src/app/features/itineraries/components/organisms/ItineraryForm/ItineraryForm.tsx
@@ -41,8 +41,7 @@ const ItineraryForm: FC<Props> = ({ teamSettings }) => {
       initialValues={ {
         teamSettings,
         numAddresses: 8,
-        daySettings: daySettingsOptions[0],
-        team_members: [ loggedInUser ]
+        daySettings: daySettingsOptions[0]
       } }
     >
       <Scaffold fields={ fields } />

--- a/src/app/features/itineraries/components/organisms/ItineraryForm/formDefinition.tsx
+++ b/src/app/features/itineraries/components/organisms/ItineraryForm/formDefinition.tsx
@@ -20,6 +20,7 @@ export const generateItineraryFormDefinition = (
       props: {
         name: "team_members[0]",
         label: "Toezichthouder 1",
+        hint: "Selecteer hier je eigen naam.",
         options: users,
         optionLabelField: "full_name",
         withEmptyOption: true,

--- a/src/app/features/shared/components/form/UniqueDropdown/UniqueDropdown.tsx
+++ b/src/app/features/shared/components/form/UniqueDropdown/UniqueDropdown.tsx
@@ -27,13 +27,14 @@ const UniqueDropdown: React.FC<UniqueDropdownProps> = ({ options, ...restProps }
     throw new Error("Given fieldname should be an item in an array. Eg. 'field[0]'.")
   }
 
-  const { input: { value: allFieldValues } } = useField(restProps.name.replace(fieldNamePattern, ""))
-  const { input: { value: ownValue } } = useField(restProps.name)
+  //const { input: { value: allFieldValues } } = useField(restProps.name.replace(fieldNamePattern, ""))
+  //const { input: { value: ownValue } } = useField(restProps.name)
 
-  const otherFieldValues = _difference(allFieldValues || [], [ownValue])
-  const filteredOptions = options?.filter(alreadySelected(otherFieldValues)) ?? []
+  //const otherFieldValues = _difference(allFieldValues || [], [ownValue])
+  //const filteredOptions = options?.filter(alreadySelected(otherFieldValues)) ?? []
 
-  return (<ComplexSelectField {...restProps} options={filteredOptions} />)
+  //return (<ComplexSelectField {...restProps} options={filteredOptions} />)
+  return (<ComplexSelectField {...restProps} options={options} />)
 }
 
 export default UniqueDropdown


### PR DESCRIPTION
This is a temporary quick fix to at least make the select dropdowns functional again. If non unique users are selected, the backend does a validation returning the following error `{"detail":"Could not create itinerary from settings: duplicate key value violates unique constraint \"itinerary_itineraryteamm_user_id_itinerary_id_a21e277c_uniq\"\nDETAIL:  Key (user_id, itinerary_id)=(a0a17150-2749-4129-ad97-f4f79eb312f4, 1861) already exists.\n"}`, so nothing can go truly wrong. Although no error is shown in the frontend.