### PR TITLE
Add .eslintignore file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/__generated__/


### PR DESCRIPTION
This should not rewrite the generated schema Typescript file (leave the `interface` statements)