### PR TITLE
Prevent itinerary card items from stretching in a flex container

### DIFF
--- a/src/app/features/shared/components/molecules/ItineraryItemCard/ItineraryItemCard.tsx
+++ b/src/app/features/shared/components/molecules/ItineraryItemCard/ItineraryItemCard.tsx
@@ -24,7 +24,6 @@ const Wrap = styled.div<WrapProps>`
   background-color: ${ props => themeColor("tint", props.backgroundColor ?? "level1") };
   padding: ${ themeSpacing(3) } ${ themeSpacing(1) };
   display: flex;
-  flex: 1;
   border-top: 1px solid ${ themeColor("tint", "level3") };
   border-bottom: 1px solid ${ themeColor("tint", "level3") };
 `


### PR DESCRIPTION
Stretch behaviour of flex items should be defined in context, not by default.