### PR TITLE
Allow adding suggestions to an itinerary

### DIFF
--- a/src/app/features/itineraries/utils/mapCaseToCardProps.tsx
+++ b/src/app/features/itineraries/utils/mapCaseToCardProps.tsx
@@ -45,13 +45,13 @@ const mapCaseToCardProps = (itineraryId: number | undefined, itineraryItemIds: R
       ? <StadiumBadge stadium={ current_states[0].status_name || "" } />
       : <StadiumBadge stadium={ stadium } />
 
-    const teamMembersList = teams && teams.length ? teams[0].map((team: { user: { full_name: string } }) => team.user.full_name).join(", ") : ""
+    const teamMembersList = teams?.length ? teams[0].map((team: { user: { full_name: string } }) => team.user.full_name).join(", ") : ""
 
     const buttons = (onDeleteButtonClick: () => void) => (
       <>
         { addDistance && distance && itineraryId && Object.keys(itineraryItemIds).length &&
         <p>{ Math.round(distance) }m</p> }
-        { teams && !teams.length && itineraryId
+        { !teams?.length && itineraryId
           ? <AddItineraryItemButton caseId={ id } itinerary={ itineraryId } />
           : null
         }

--- a/src/app/features/shared/components/form/AddressPicker/components/StartAddressSearchResults/StartAddressSearchResults.tsx
+++ b/src/app/features/shared/components/form/AddressPicker/components/StartAddressSearchResults/StartAddressSearchResults.tsx
@@ -42,7 +42,7 @@ const mapResults = (handleAdd: HandleAddCallback, getUrl: (string: string) => st
     teams
   }: any
 ): React.ComponentProps<typeof ItineraryItemCard> => {
-  const teamMembersList = teams && teams.length ? teams[0].map((team: { user: { full_name: string } }) => team.user.full_name).join(", ") : ""
+  const teamMembersList = teams?.length ? teams[0].map((team: { user: { full_name: string } }) => team.user.full_name).join(", ") : ""
 
   return {
     href: getUrl(id),
@@ -52,7 +52,8 @@ const mapResults = (handleAdd: HandleAddCallback, getUrl: (string: string) => st
     reason: case_reason,
     badge: <StadiumBadge stadium={ stadium } />,
     fraudProbability: <FraudProbability fraudProbability={ fraud_prediction?.fraud_probability } />,
-    buttons: teamMembersList ? undefined : (() => <StyledButton icon={ <Enlarge /> } onClick={ () => handleAdd(id) } />),
+    buttons: teamMembersList ? undefined : (() => <StyledButton icon={ <Enlarge /> }
+                                                                onClick={ () => handleAdd(id) } />),
     teamMembersList
   }
 }


### PR DESCRIPTION
The suggestions endpoint doesn’t send `teams` info so we need to relax our conditions.